### PR TITLE
fix: Prevents invalid stream for null payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## 0.1.1 - 2024-01-15
+
+### Fixed
+
+- Resolved invalid streams being created for null payloads
+
 ## dev - 2024-01-10
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -176,12 +176,14 @@ class Client
             [new JsonEncoder()],
         );
 
-        $body = $serializer->serialize($payload, 'json');
+        if ($payload !== null) {
+            $body = $serializer->serialize($payload, 'json');
 
-        $request = $request->withBody(
-            // Satisfies empty body requests.
-            $this->streamFactory->createStream($body === '[]' ? '{}' : $body),
-        );
+            $request = $request->withBody(
+                // Satisfies empty body requests.
+                $this->streamFactory->createStream($body === '[]' ? '{}' : $body),
+            );
+        }
 
         $request = $request->withAddedHeader('X-Transaction-ID', $this->transactionId ?? (string) new Ulid());
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '0.1.0';
+    private const SDK_VERSION = '0.1.1';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;


### PR DESCRIPTION
Resolves: #3

Any of our resource clients utilising a `null` payload may result in a `"null"` body on the request stream. 

This solution prevents a stream being created on the request if no payload was intended. 

_Note this issue looks like it may only surface when specific HTTP Client/s are used, I've not pinpointed where this happens or which packages would be susceptible_