### PR TITLE
Removal of php-http/message-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "php-http/httplug": "^1.1 || ^2.0",
     "php-http/logger-plugin": "^1.3",
     "php-http/message": "^1.5",
-    "php-http/message-factory": "^1.1",
     "psr/http-factory": "^1.0",
     "psr/http-factory-implementation": "^1.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",


### PR DESCRIPTION
In this pull request, php-http/message-factory is removed since it is not used in the library and it is deprecated.