### PR TITLE
Sync API spec with SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [0.2.1] - 2024-01-24
+
+### Added
+
+- Added `importMeta` to product, price, address, business, customer, discount and subscription entities
+- Added `creditToBalance` to `transaction.details.payoutTotals` and `transaction.details.totals`
+- Added `origin` query parameter to list transactions, see [related changelog](https://developer.paddle.com/changelog/2023/filter-transactions-origin?utm_source=dx&utm_medium=paddle-php-sdk).
+- Added `available_payment_methods` to transaction with includes entity
+- Added `email` query parameter to list customers, see [related changelog](https://developer.paddle.com/changelog/2024/filter-customers-email#filter-customers-by-email-address?utm_source=dx&utm_medium=paddle-php-sdk)
+
 ## [0.2.0] - 2024-01-23
 
 ### Changed
@@ -25,10 +35,10 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 ### Added
 
-- Added `available_payment_methods` to [transaction preview and pricing preview](https://developer.paddle.com/changelog/2023/available-payment-methods?utm_source=dx&utm_medium=paddle-node-sdk)
-- Added non-catalog items to [subscriptions](https://developer.paddle.com/changelog/2023/bill-custom-items-one-time-subscription-charge?utm_source=dx&utm_medium=paddle-node-sdk)
-- Added non catalog items to [transactions](https://developer.paddle.com/changelog/2023/add-custom-items-transaction?utm_source=dx&utm_medium=paddle-node-sdk)
-- Added `on_payment_failure` to [subscriptions](https://developer.paddle.com/changelog/2023/payment-failure-behavior-update-subscription?utm_source=dx&utm_medium=paddle-node-sdk)
+- Added `available_payment_methods` to [transaction preview and pricing preview](https://developer.paddle.com/changelog/2023/available-payment-methods?utm_source=dx&utm_medium=paddle-php-sdk)
+- Added non-catalog items to [subscriptions](https://developer.paddle.com/changelog/2023/bill-custom-items-one-time-subscription-charge?utm_source=dx&utm_medium=paddle-php-sdk)
+- Added non catalog items to [transactions](https://developer.paddle.com/changelog/2023/add-custom-items-transaction?utm_source=dx&utm_medium=paddle-php-sdk)
+- Added `on_payment_failure` to [subscriptions](https://developer.paddle.com/changelog/2023/payment-failure-behavior-update-subscription?utm_source=dx&utm_medium=paddle-php-sdk)
 
 ### Fixed
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '0.2.0';
+    private const SDK_VERSION = '0.2.1';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;

--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Shared\CountryCode;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\Status;
 
 class Address implements Entity
@@ -30,6 +31,7 @@ class Address implements Entity
         public Status $status,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface $updatedAt,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -48,6 +50,7 @@ class Address implements Entity
             status: Status::from($data['status']),
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Business.php
+++ b/src/Entities/Business.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Shared\Contacts;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\Status;
 
 class Business implements Entity
@@ -30,6 +31,7 @@ class Business implements Entity
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface $updatedAt,
         public CustomData|null $customData,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -45,6 +47,7 @@ class Business implements Entity
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Customer.php
+++ b/src/Entities/Customer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\Status;
 
 class Customer implements Entity
@@ -26,6 +27,7 @@ class Customer implements Entity
         public string $locale,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface $updatedAt,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -41,6 +43,7 @@ class Customer implements Entity
             locale: $data['locale'],
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Discount.php
+++ b/src/Entities/Discount.php
@@ -14,6 +14,7 @@ namespace Paddle\SDK\Entities;
 use Paddle\SDK\Entities\Discount\DiscountStatus;
 use Paddle\SDK\Entities\Discount\DiscountType;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 
 class Discount implements Entity
 {
@@ -34,6 +35,7 @@ class Discount implements Entity
         public int $timesUsed,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface $updatedAt,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -56,6 +58,7 @@ class Discount implements Entity
             timesUsed: $data['times_used'],
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Price.php
+++ b/src/Entities/Price.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\Status;
@@ -39,6 +40,7 @@ class Price implements Entity
         public PriceQuantity $quantity,
         public Status $status,
         public CustomData|null $customData,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -61,6 +63,7 @@ class Price implements Entity
             quantity: PriceQuantity::from($data['quantity']),
             status: Status::from($data['status']),
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Product.php
+++ b/src/Entities/Product.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\Status;
 use Paddle\SDK\Entities\Shared\TaxCategory;
 
@@ -28,6 +29,7 @@ class Product implements Entity
         public CustomData|null $customData,
         public Status $status,
         public \DateTimeInterface|null $createdAt,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -43,6 +45,7 @@ class Product implements Entity
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
             status: Status::from($data['status']),
             createdAt: isset($data['created_at']) ? DateTime::from($data['created_at']) : null,
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/Shared/ImportMeta.php
+++ b/src/Entities/Shared/ImportMeta.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Shared;
+
+class ImportMeta
+{
+    public function __construct(
+        public readonly string|null $externalId,
+        public readonly string $importedFrom,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            externalId: $data['external_id'] ?? null,
+            importedFrom: $data['imported_from'],
+        );
+    }
+}

--- a/src/Entities/Shared/TransactionPayoutTotals.php
+++ b/src/Entities/Shared/TransactionPayoutTotals.php
@@ -24,22 +24,24 @@ class TransactionPayoutTotals
         public string $fee,
         public string $earnings,
         public CurrencyCodePayouts $currencyCode,
+        public string $creditToBalance,
     ) {
     }
 
     public static function from(array $data): self
     {
         return new self(
-            $data['subtotal'],
-            $data['discount'],
-            $data['tax'],
-            $data['total'],
-            $data['credit'],
-            $data['balance'],
-            $data['grand_total'],
-            $data['fee'] ?? null,
-            $data['earnings'] ?? null,
-            CurrencyCodePayouts::from($data['currency_code']),
+            subtotal: $data['subtotal'],
+            discount: $data['discount'],
+            tax: $data['tax'],
+            total: $data['total'],
+            credit: $data['credit'],
+            balance: $data['balance'],
+            grandTotal: $data['grand_total'],
+            fee: $data['fee'] ?? null,
+            earnings: $data['earnings'] ?? null,
+            currencyCode: CurrencyCodePayouts::from($data['currency_code']),
+            creditToBalance: $data['credit_to_balance'],
         );
     }
 }

--- a/src/Entities/Shared/TransactionTotals.php
+++ b/src/Entities/Shared/TransactionTotals.php
@@ -24,6 +24,7 @@ class TransactionTotals
         public string|null $fee,
         public string|null $earnings,
         public CurrencyCode $currencyCode,
+        public string $creditToBalance,
     ) {
     }
 
@@ -40,6 +41,7 @@ class TransactionTotals
             fee: $data['fee'] ?? null,
             earnings: $data['earnings'] ?? null,
             currencyCode: CurrencyCode::from($data['currency_code']),
+            creditToBalance: $data['credit_to_balance'],
         );
     }
 }

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -15,6 +15,7 @@ use Paddle\SDK\Entities\Shared\BillingDetails;
 use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\ImportMeta;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Subscription\SubscriptionDiscount;
 use Paddle\SDK\Entities\Subscription\SubscriptionItem;
@@ -51,6 +52,7 @@ class Subscription implements Entity
         public SubscriptionManagementUrls $managementUrls,
         public array $items,
         public CustomData|null $customData,
+        public ImportMeta|null $importMeta,
     ) {
     }
 
@@ -85,6 +87,7 @@ class Subscription implements Entity
                 : null,
             items: array_map(fn (array $item): SubscriptionItem => SubscriptionItem::from($item), $data['items']),
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
+            importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
         );
     }
 }

--- a/src/Entities/TransactionWithIncludes.php
+++ b/src/Entities/TransactionWithIncludes.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities;
 
+use Paddle\SDK\Entities\Shared\AvailablePaymentMethods;
 use Paddle\SDK\Entities\Shared\BillingDetails;
 use Paddle\SDK\Entities\Shared\Checkout;
 use Paddle\SDK\Entities\Shared\CollectionMode;
@@ -31,6 +32,7 @@ class TransactionWithIncludes implements Entity
      * @param array<TransactionItem>           $items
      * @param array<TransactionPaymentAttempt> $payments
      * @param array<TransactionAdjustment>     $adjustments
+     * @param array<AvailablePaymentMethods>   $availablePaymentMethods
      */
     public function __construct(
         public string $id,
@@ -61,6 +63,7 @@ class TransactionWithIncludes implements Entity
         public Business|null $business,
         public Customer|null $customer,
         public Discount|null $discount,
+        public array $availablePaymentMethods,
     ) {
     }
 
@@ -95,6 +98,7 @@ class TransactionWithIncludes implements Entity
             business: isset($data['business']) ? Business::from($data['business']) : null,
             customer: isset($data['customer']) ? Customer::from($data['customer']) : null,
             discount: isset($data['discount']) ? Discount::from($data['discount']) : null,
+            availablePaymentMethods: array_map(fn (string $item): AvailablePaymentMethods => AvailablePaymentMethods::from($item), $data['available_payment_methods'] ?? []),
         );
     }
 }

--- a/src/Resources/Customers/Operations/ListCustomers.php
+++ b/src/Resources/Customers/Operations/ListCustomers.php
@@ -22,6 +22,7 @@ class ListCustomers implements HasParameters
         private readonly array $ids = [],
         private readonly array $statuses = [],
         private readonly ?string $search = null,
+        private readonly array $emails = [],
     ) {
         if ($invalid = array_filter($this->ids, fn ($value): bool => ! is_string($value))) {
             throw InvalidArgumentException::arrayContainsInvalidTypes('ids', 'string', implode(', ', $invalid));
@@ -29,6 +30,10 @@ class ListCustomers implements HasParameters
 
         if ($invalid = array_filter($this->statuses, fn ($value): bool => ! $value instanceof Status)) {
             throw InvalidArgumentException::arrayContainsInvalidTypes('statuses', Status::class, implode(', ', $invalid));
+        }
+
+        if ($invalid = array_filter($this->emails, fn ($value): bool => ! is_string($value))) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('emails', 'string', implode(', ', $invalid));
         }
     }
 
@@ -42,6 +47,7 @@ class ListCustomers implements HasParameters
                 'id' => implode(',', $this->ids),
                 'status' => implode(',', array_map($enumStringify, $this->statuses)),
                 'search' => $this->search,
+                'email' => implode(',', $this->emails),
             ]),
         );
     }

--- a/src/Resources/Transactions/Operations/List/Includes.php
+++ b/src/Resources/Transactions/Operations/List/Includes.php
@@ -9,6 +9,7 @@ enum Includes: string
     case Address = 'address';
     case Adjustment = 'adjustment';
     case AdjustmentsTotals = 'adjustments_totals';
+    case AvailablePaymentMethods = 'available_payment_methods';
     case Business = 'business';
     case Customer = 'customer';
     case Discount = 'discount';

--- a/src/Resources/Transactions/Operations/List/Origin.php
+++ b/src/Resources/Transactions/Operations/List/Origin.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\List;
+
+enum Origin: string
+{
+    case Api = 'api';
+    case SubscriptionCharge = 'subscription_charge';
+    case SubscriptionPaymentMethodChange = 'subscription_payment_method_change';
+    case SubscriptionRecurring = 'subscription_recurring';
+    case SubscriptionUpdate = 'subscription_update';
+    case Web = 'web';
+}

--- a/src/Resources/Transactions/Operations/ListTransactions.php
+++ b/src/Resources/Transactions/Operations/ListTransactions.php
@@ -11,6 +11,7 @@ use Paddle\SDK\HasParameters;
 use Paddle\SDK\Resources\Shared\Operations\List\DateComparison;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
+use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
 
 class ListTransactions implements HasParameters
 {
@@ -21,6 +22,7 @@ class ListTransactions implements HasParameters
      * @param array<string>            $invoiceNumbers
      * @param array<StatusTransaction> $statuses
      * @param array<string>            $subscriptionIds
+     * @param array<Origin>            $origin
      */
     public function __construct(
         private readonly ?Pager $pager = null,
@@ -34,6 +36,7 @@ class ListTransactions implements HasParameters
         private readonly array $statuses = [],
         private readonly array $subscriptionIds = [],
         private readonly ?DateComparison $updatedAt = null,
+        private readonly array $origin = [],
     ) {
         if ($invalid = array_filter($this->customerIds, fn ($value): bool => ! is_string($value))) {
             throw InvalidArgumentException::arrayContainsInvalidTypes('customerIds', 'string', implode(', ', $invalid));
@@ -58,6 +61,10 @@ class ListTransactions implements HasParameters
         if ($invalid = array_filter($this->subscriptionIds, fn ($value): bool => ! is_string($value))) {
             throw InvalidArgumentException::arrayContainsInvalidTypes('subscriptionIds', 'string', implode(', ', $invalid));
         }
+
+        if ($invalid = array_filter($this->origin, fn ($value): bool => ! $value instanceof Origin)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('origin', Origin::class, implode(', ', $invalid));
+        }
     }
 
     public function getParameters(): array
@@ -77,6 +84,7 @@ class ListTransactions implements HasParameters
                 'status' => implode(',', array_map($enumStringify, $this->statuses)),
                 'subscription_id' => implode(',', $this->subscriptionIds),
                 'updated_at' . $this->updatedAt?->comparator() => $this->updatedAt?->formatted(),
+                'origin' => implode(',', array_map($enumStringify, $this->origin)),
             ]),
         );
     }

--- a/src/Resources/Transactions/Operations/ListTransactions.php
+++ b/src/Resources/Transactions/Operations/ListTransactions.php
@@ -22,7 +22,7 @@ class ListTransactions implements HasParameters
      * @param array<string>            $invoiceNumbers
      * @param array<StatusTransaction> $statuses
      * @param array<string>            $subscriptionIds
-     * @param array<Origin>            $origin
+     * @param array<Origin>            $origins
      */
     public function __construct(
         private readonly ?Pager $pager = null,
@@ -36,7 +36,7 @@ class ListTransactions implements HasParameters
         private readonly array $statuses = [],
         private readonly array $subscriptionIds = [],
         private readonly ?DateComparison $updatedAt = null,
-        private readonly array $origin = [],
+        private readonly array $origins = [],
     ) {
         if ($invalid = array_filter($this->customerIds, fn ($value): bool => ! is_string($value))) {
             throw InvalidArgumentException::arrayContainsInvalidTypes('customerIds', 'string', implode(', ', $invalid));
@@ -62,8 +62,8 @@ class ListTransactions implements HasParameters
             throw InvalidArgumentException::arrayContainsInvalidTypes('subscriptionIds', 'string', implode(', ', $invalid));
         }
 
-        if ($invalid = array_filter($this->origin, fn ($value): bool => ! $value instanceof Origin)) {
-            throw InvalidArgumentException::arrayContainsInvalidTypes('origin', Origin::class, implode(', ', $invalid));
+        if ($invalid = array_filter($this->origins, fn ($value): bool => ! $value instanceof Origin)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('origins', Origin::class, implode(', ', $invalid));
         }
     }
 
@@ -84,7 +84,7 @@ class ListTransactions implements HasParameters
                 'status' => implode(',', array_map($enumStringify, $this->statuses)),
                 'subscription_id' => implode(',', $this->subscriptionIds),
                 'updated_at' . $this->updatedAt?->comparator() => $this->updatedAt?->formatted(),
-                'origin' => implode(',', array_map($enumStringify, $this->origin)),
+                'origin' => implode(',', array_map($enumStringify, $this->origins)),
             ]),
         );
     }

--- a/tests/Functional/Resources/Customers/CustomersClientTest.php
+++ b/tests/Functional/Resources/Customers/CustomersClientTest.php
@@ -194,6 +194,12 @@ class CustomersClientTest extends TestCase
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/customers?search=Alex', Environment::SANDBOX->baseUrl()),
         ];
+
+        yield 'Email Filtered' => [
+            new ListCustomers(emails: ['dx@paddle.com']),
+            new Response(200, body: self::readRawJsonFixture('response/list_default')),
+            sprintf('%s/customers?email=dx@paddle.com', Environment::SANDBOX->baseUrl()),
+        ];
     }
 
     /** @test */

--- a/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
@@ -167,6 +167,7 @@
                             "tax": "11980",
                             "total": "71880",
                             "credit": "0",
+                            "credit_to_balance": "0",
                             "balance": "71880",
                             "discount": "0",
                             "earnings": null,

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/get_payment_method_change_transaction_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/get_payment_method_change_transaction_entity.json
@@ -82,6 +82,7 @@
                 "total": "0",
                 "fee": null,
                 "credit": "0",
+                "credit_to_balance": "0",
                 "balance": "0",
                 "grand_total": "0",
                 "earnings": null,

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
@@ -203,6 +203,7 @@
         "total": "194341",
         "fee": null,
         "credit": "0",
+        "credit_to_balance": "0",
         "balance": "194341",
         "grand_total": "194341",
         "earnings": null,

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -30,6 +30,7 @@ use Paddle\SDK\Resources\Shared\Operations\List\DateComparison;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
+use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
 use Paddle\SDK\Resources\Transactions\Operations\PreviewTransaction;
 use Paddle\SDK\Resources\Transactions\Operations\UpdateTransaction;
@@ -371,6 +372,12 @@ class TransactionsClientTest extends TestCase
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/transactions?include=customer,address,discount', Environment::SANDBOX->baseUrl()),
         ];
+
+        yield 'With Origin' => [
+            new ListTransactions(origin: [Origin::Web, Origin::Api, Origin::SubscriptionRecurring]),
+            new Response(200, body: self::readRawJsonFixture('response/list_default')),
+            sprintf('%s/transactions?origin=web,api,subscription_recurring', Environment::SANDBOX->baseUrl()),
+        ];
     }
 
     /**
@@ -403,9 +410,9 @@ class TransactionsClientTest extends TestCase
         ];
 
         yield 'With Includes' => [
-            [Includes::Customer, Includes::Address, Includes::Business, Includes::Discount],
+            [Includes::Customer, Includes::Address, Includes::Business, Includes::Discount, Includes::AvailablePaymentMethods],
             new Response(200, body: self::readRawJsonFixture('response/full_entity_with_includes')),
-            sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r?include=customer,address,business,discount', Environment::SANDBOX->baseUrl()),
+            sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r?include=customer,address,business,discount,available_payment_methods', Environment::SANDBOX->baseUrl()),
         ];
     }
 

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -373,8 +373,8 @@ class TransactionsClientTest extends TestCase
             sprintf('%s/transactions?include=customer,address,discount', Environment::SANDBOX->baseUrl()),
         ];
 
-        yield 'With Origin' => [
-            new ListTransactions(origin: [Origin::Web, Origin::Api, Origin::SubscriptionRecurring]),
+        yield 'With Origins' => [
+            new ListTransactions(origins: [Origin::Web, Origin::Api, Origin::SubscriptionRecurring]),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/transactions?origin=web,api,subscription_recurring', Environment::SANDBOX->baseUrl()),
         ];

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -98,6 +98,7 @@
         "grand_total": "2915",
         "fee": null,
         "credit": "0",
+        "credit_to_balance": "0",
         "balance": "2915",
         "earnings": null,
         "currency_code": "GBP"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity_with_includes.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity_with_includes.json
@@ -98,6 +98,7 @@
         "grand_total": "2915",
         "fee": null,
         "credit": "0",
+        "credit_to_balance": "0",
         "balance": "2915",
         "earnings": null,
         "currency_code": "GBP"
@@ -211,7 +212,8 @@
       "times_used": 0,
       "created_at": "2023-11-07T15:45:28.561Z",
       "updated_at": "2023-11-07T15:45:28.561Z"
-    }
+    },
+    "available_payment_methods": ["apple_pay"]
   },
   "meta": {
     "request_id": "f3dd61c8-045a-4975-95c3-a361ff2abcc6"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -131,6 +131,7 @@
           "grand_total": "901387",
           "fee": null,
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "901387",
           "earnings": null,
           "currency_code": "USD"
@@ -372,6 +373,7 @@
           "grand_total": "72479",
           "fee": null,
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "72479",
           "earnings": null,
           "currency_code": "USD"
@@ -613,6 +615,7 @@
           "grand_total": "59900",
           "fee": null,
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "59900",
           "earnings": null,
           "currency_code": "USD"
@@ -806,6 +809,7 @@
           "grand_total": "40000",
           "fee": "2050",
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "0",
           "earnings": "37950",
           "currency_code": "USD"
@@ -825,6 +829,7 @@
           "discount": "0",
           "total": "40000",
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "0",
           "grand_total": "40000",
           "fee": "2050",
@@ -999,6 +1004,7 @@
           "grand_total": "5000",
           "fee": null,
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "5000",
           "earnings": null,
           "currency_code": "USD"
@@ -1148,6 +1154,7 @@
           "grand_total": "43549",
           "fee": null,
           "credit": "0",
+          "credit_to_balance": "0",
           "balance": "43549",
           "earnings": null,
           "currency_code": "USD"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
@@ -129,6 +129,7 @@
                     "grand_total": "901387",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "901387",
                     "earnings": null,
                     "currency_code": "USD"
@@ -364,6 +365,7 @@
                     "grand_total": "72479",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "72479",
                     "earnings": null,
                     "currency_code": "USD"
@@ -599,6 +601,7 @@
                     "grand_total": "59900",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "59900",
                     "earnings": null,
                     "currency_code": "USD"
@@ -792,6 +795,7 @@
                     "grand_total": "40000",
                     "fee": "2050",
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "0",
                     "earnings": "37950",
                     "currency_code": "USD"
@@ -811,6 +815,7 @@
                     "discount": "0",
                     "total": "40000",
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "0",
                     "grand_total": "40000",
                     "fee": "2050",
@@ -985,6 +990,7 @@
                     "grand_total": "5000",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "5000",
                     "earnings": null,
                     "currency_code": "USD"
@@ -1134,6 +1140,7 @@
                     "grand_total": "43549",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "43549",
                     "earnings": null,
                     "currency_code": "USD"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
@@ -129,6 +129,7 @@
                     "grand_total": "901387",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "901387",
                     "earnings": null,
                     "currency_code": "USD"
@@ -364,6 +365,7 @@
                     "grand_total": "72479",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "72479",
                     "earnings": null,
                     "currency_code": "USD"
@@ -599,6 +601,7 @@
                     "grand_total": "59900",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "59900",
                     "earnings": null,
                     "currency_code": "USD"
@@ -792,6 +795,7 @@
                     "grand_total": "40000",
                     "fee": "2050",
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "0",
                     "earnings": "37950",
                     "currency_code": "USD"
@@ -811,6 +815,7 @@
                     "discount": "0",
                     "total": "40000",
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "0",
                     "grand_total": "40000",
                     "fee": "2050",
@@ -985,6 +990,7 @@
                     "grand_total": "5000",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "5000",
                     "earnings": null,
                     "currency_code": "USD"
@@ -1134,6 +1140,7 @@
                     "grand_total": "43549",
                     "fee": null,
                     "credit": "0",
+                    "credit_to_balance": "0",
                     "balance": "43549",
                     "earnings": null,
                     "currency_code": "USD"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/minimal_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/minimal_entity.json
@@ -66,6 +66,7 @@
         "grand_total": "0",
         "fee": null,
         "credit": "0",
+        "credit_to_balance": "0",
         "balance": "0",
         "earnings": null,
         "currency_code": "USD"

--- a/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
@@ -93,6 +93,7 @@
                 "grand_total": "540000",
                 "fee": null,
                 "credit": "0",
+                "credit_to_balance": "0",
                 "balance": "540000",
                 "earnings": null,
                 "currency_code": "USD"


### PR DESCRIPTION
### Added

- Added `importMeta` to product, price, address, business, customer, discount and subscription entities
- Added `creditToBalance` to `transaction.details.payoutTotals` and `transaction.details.totals`
- Added `origin` query parameter to list transactions, see [related changelog](https://developer.paddle.com/changelog/2023/filter-transactions-origin?utm_source=dx&utm_medium=paddle-php-sdk).
- Added `available_payment_methods` to transaction with includes entity
- Added `email` query parameter to list customers, see [related changelog](https://developer.paddle.com/changelog/2024/filter-customers-email#filter-customers-by-email-address?utm_source=dx&utm_medium=paddle-php-sdk)
