### PR TITLE
Fix transaction invoice PDF endpoint URL 

### DIFF
--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -131,7 +131,7 @@ class TransactionsClient
     public function getInvoicePDF(string $id): TransactionData
     {
         $parser = new ResponseParser(
-            $this->client->getRaw("/transactions/{$id}/preview"),
+            $this->client->getRaw("/transactions/{$id}/invoice"),
         );
 
         return TransactionData::from($parser->getData());


### PR DESCRIPTION
Get transaction invoice PDF endpoint should be `/transactions/{$id}/invoice` per https://developer.paddle.com/api-reference/transactions/get-invoice-pdf