### PR TITLE
TransactionLineItem should contain Product instead of ProductWithIncludes

### DIFF
--- a/src/Entities/Shared/TransactionLineItemPreview.php
+++ b/src/Entities/Shared/TransactionLineItemPreview.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Shared;
 
-use Paddle\SDK\Entities\ProductWithIncludes;
+use Paddle\SDK\Entities\Product;
 
 class TransactionLineItemPreview
 {
@@ -21,7 +21,7 @@ class TransactionLineItemPreview
         public string $taxRate,
         public UnitTotals $unitTotals,
         public Totals $totals,
-        public ProductWithIncludes $product,
+        public Product $product,
     ) {
     }
 
@@ -33,7 +33,7 @@ class TransactionLineItemPreview
             $data['tax_rate'],
             UnitTotals::from($data['unit_totals']),
             Totals::from($data['totals']),
-            ProductWithIncludes::from($data['product']),
+            Product::from($data['product']),
         );
     }
 }

--- a/src/Entities/Transaction/TransactionLineItem.php
+++ b/src/Entities/Transaction/TransactionLineItem.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
-use Paddle\SDK\Entities\ProductWithIncludes;
+use Paddle\SDK\Entities\Product;
 use Paddle\SDK\Entities\Shared\Totals;
 use Paddle\SDK\Entities\Shared\UnitTotals;
 
@@ -25,7 +25,7 @@ class TransactionLineItem
         public string $taxRate,
         public UnitTotals $unitTotals,
         public Totals $totals,
-        public ProductWithIncludes $product,
+        public Product $product,
     ) {
     }
 
@@ -39,7 +39,7 @@ class TransactionLineItem
             $data['tax_rate'],
             UnitTotals::from($data['unit_totals']),
             Totals::from($data['totals']),
-            ProductWithIncludes::from($data['product']),
+            Product::from($data['product']),
         );
     }
 }


### PR DESCRIPTION
The disclaimer at the top of the file says the code is auto-generated, I'm not positive this is a bug but according to [the API spec](https://developer.paddle.com/api-reference/transactions/overview), it seems that this should be using `Product` instead of `ProductWithIncludes`. Also, had to submit as a PR because GitHub discussions doesn't seem to be enabled for this repo. I haven't looked into TransactionLineItemPreview yet, I suspect it'll need the save review.