### PR TITLE
Fix list notifications test case in NotificationsClientTest.php

### DIFF
--- a/tests/Functional/Resources/Notifications/NotificationsClientTest.php
+++ b/tests/Functional/Resources/Notifications/NotificationsClientTest.php
@@ -124,9 +124,9 @@ class NotificationsClientTest extends TestCase
         ];
 
         yield 'From Filtered' => [
-            new ListNotifications(to: new \DateTime('2023-12-25T00:00:00.000Z')),
+            new ListNotifications(from: new \DateTime('2023-12-25T00:00:00.000Z')),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
-            sprintf('%s/notifications?to=2023-12-25T00:00:00.000000Z', Environment::SANDBOX->baseUrl()),
+            sprintf('%s/notifications?from=2023-12-25T00:00:00.000000Z', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'To and From Filtered' => [

--- a/tests/Functional/Resources/Notifications/NotificationsClientTest.php
+++ b/tests/Functional/Resources/Notifications/NotificationsClientTest.php
@@ -124,9 +124,9 @@ class NotificationsClientTest extends TestCase
         ];
 
         yield 'From Filtered' => [
-            new ListNotifications(from: new \DateTime('2023-12-25T00:00:00.000Z')),
+            new ListNotifications(from: new \DateTime('2023-12-24T00:00:00.000Z')),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
-            sprintf('%s/notifications?from=2023-12-25T00:00:00.000000Z', Environment::SANDBOX->baseUrl()),
+            sprintf('%s/notifications?from=2023-12-24T00:00:00.000000Z', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'To and From Filtered' => [


### PR DESCRIPTION
Looks like this test was copied from the `to:` version and the parameter wasn't changed to `from:`, you can see the `to:` version above this one