### PR TITLE
NotificationSubscription()->$currentBillingPeriod should be nullable

### DIFF
--- a/src/Entities/Notification/NotificationSubscription.php
+++ b/src/Entities/Notification/NotificationSubscription.php
@@ -39,7 +39,7 @@ class NotificationSubscription implements Entity
         public SubscriptionDiscount|null $discount,
         public CollectionMode $collectionMode,
         public BillingDetails|null $billingDetails,
-        public SubscriptionTimePeriod $currentBillingPeriod,
+        public SubscriptionTimePeriod|null $currentBillingPeriod,
         public TimePeriod $billingCycle,
         public SubscriptionScheduledChange|null $scheduledChange,
         public array $items,


### PR DESCRIPTION
According to the API spec: https://developer.paddle.com/webhooks/subscriptions/subscription-updated