### PR TITLE
fix(deps): Pin CS Fixer to previous version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "symfony/serializer": "^5.4 || ^6.3 || ^7.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.35",
+    "friendsofphp/php-cs-fixer": "3.48",
     "guzzlehttp/psr7": "^2.6",
     "monolog/monolog": "^3.5",
     "php-http/curl-client": "^2.3",


### PR DESCRIPTION
CS Fixer recently made some changes that causes us some issues. 

To resolve this at least for now I've pinned to the previous version of CS Fixer. This should be fine as a dev dependency. 

Our pipeline also needs to split out to prevent lint running on multiple version of CS Fixer (configuration may change and become incompatible). 