### PR TITLE
fix!: Make implementors of Entity internal

### DIFF
--- a/src/Entities/Address.php
+++ b/src/Entities/Address.php
@@ -18,7 +18,10 @@ use Paddle\SDK\Entities\Shared\Status;
 
 class Address implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public string|null $description,
         public string|null $firstLine,

--- a/src/Entities/Adjustment.php
+++ b/src/Entities/Adjustment.php
@@ -21,9 +21,11 @@ use Paddle\SDK\Entities\Shared\TotalAdjustments;
 class Adjustment implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<AdjustmentItemTotals> $items
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public Action $action,
         public string $transactionId,

--- a/src/Entities/Business.php
+++ b/src/Entities/Business.php
@@ -19,9 +19,11 @@ use Paddle\SDK\Entities\Shared\Status;
 class Business implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<Contacts> $contacts
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public string $name,
         public string|null $companyNumber,

--- a/src/Entities/CreditBalance.php
+++ b/src/Entities/CreditBalance.php
@@ -16,7 +16,10 @@ use Paddle\SDK\Entities\Shared\CurrencyCode;
 
 class CreditBalance implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $customerId,
         public CurrencyCode $currencyCode,
         public AdjustmentCustomerBalance $balance,

--- a/src/Entities/Customer.php
+++ b/src/Entities/Customer.php
@@ -17,7 +17,10 @@ use Paddle\SDK\Entities\Shared\Status;
 
 class Customer implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public string|null $name,
         public string $email,

--- a/src/Entities/Discount.php
+++ b/src/Entities/Discount.php
@@ -18,7 +18,10 @@ use Paddle\SDK\Entities\Shared\ImportMeta;
 
 class Discount implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public DiscountStatus $status,
         public string $description,

--- a/src/Entities/Event.php
+++ b/src/Entities/Event.php
@@ -10,7 +10,10 @@ use Paddle\SDK\Entities\Notification\NotificationSubscription;
 
 class Event implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $eventId,
         public EventTypeName $eventType,
         public \DateTimeInterface $occurredAt,

--- a/src/Entities/EventType.php
+++ b/src/Entities/EventType.php
@@ -15,7 +15,10 @@ use Paddle\SDK\Entities\Event\EventTypeName;
 
 class EventType implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public EventTypeName $name,
         public string $description,
         public string $group,

--- a/src/Entities/Notification.php
+++ b/src/Entities/Notification.php
@@ -10,7 +10,10 @@ use Paddle\SDK\Entities\Notification\NotificationStatus;
 
 class Notification implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public EventTypeName $type,
         public NotificationStatus $status,

--- a/src/Entities/Notification/NotificationDiscount.php
+++ b/src/Entities/Notification/NotificationDiscount.php
@@ -19,7 +19,10 @@ use Paddle\SDK\Entities\Shared\CurrencyCode;
 
 class NotificationDiscount implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public DiscountStatus $status,
         public string $description,

--- a/src/Entities/Notification/NotificationSubscription.php
+++ b/src/Entities/Notification/NotificationSubscription.php
@@ -20,9 +20,11 @@ use Paddle\SDK\Entities\Subscription\SubscriptionTimePeriod;
 class NotificationSubscription implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<SubscriptionItem> $items
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public SubscriptionStatus $status,
         public string $customerId,

--- a/src/Entities/NotificationLog.php
+++ b/src/Entities/NotificationLog.php
@@ -6,7 +6,10 @@ namespace Paddle\SDK\Entities;
 
 class NotificationLog implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public int $responseCode,
         public string|null $responseContentType,

--- a/src/Entities/NotificationSetting.php
+++ b/src/Entities/NotificationSetting.php
@@ -16,7 +16,10 @@ use Paddle\SDK\Entities\NotificationSetting\NotificationSettingType;
 
 class NotificationSetting implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public string $description,
         public NotificationSettingType $type,

--- a/src/Entities/Price.php
+++ b/src/Entities/Price.php
@@ -24,9 +24,11 @@ use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 class Price implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<UnitPriceOverride> $unitPriceOverrides
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public string $productId,
         public string|null $name,

--- a/src/Entities/PricePreview.php
+++ b/src/Entities/PricePreview.php
@@ -19,9 +19,11 @@ use Paddle\SDK\Entities\Shared\CurrencyCode;
 class PricePreview implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<AvailablePaymentMethods> $availablePaymentMethods
      */
-    public function __construct(
+    protected function __construct(
         public string|null $customerId,
         public string|null $addressId,
         public string|null $businessId,

--- a/src/Entities/PricingPreview/PricePreviewDetails.php
+++ b/src/Entities/PricingPreview/PricePreviewDetails.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\PricingPreview;
 
-use Paddle\SDK\Entities\Entity;
-
-class PricePreviewDetails implements Entity
+class PricePreviewDetails
 {
     /**
      * @param array<PricePreviewLineItem> $lineItems

--- a/src/Entities/PricingPreview/PricePreviewDiscounts.php
+++ b/src/Entities/PricingPreview/PricePreviewDiscounts.php
@@ -12,9 +12,8 @@ declare(strict_types=1);
 namespace Paddle\SDK\Entities\PricingPreview;
 
 use Paddle\SDK\Entities\Discount;
-use Paddle\SDK\Entities\Entity;
 
-class PricePreviewDiscounts implements Entity
+class PricePreviewDiscounts
 {
     public function __construct(
         public Discount $discount,

--- a/src/Entities/PricingPreview/PricePreviewItem.php
+++ b/src/Entities/PricingPreview/PricePreviewItem.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\PricingPreview;
 
-use Paddle\SDK\Entities\Entity;
-
-class PricePreviewItem implements Entity
+class PricePreviewItem
 {
     public function __construct(
         public string $priceId,

--- a/src/Entities/PricingPreview/PricePreviewLineItem.php
+++ b/src/Entities/PricingPreview/PricePreviewLineItem.php
@@ -11,13 +11,12 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\PricingPreview;
 
-use Paddle\SDK\Entities\Entity;
 use Paddle\SDK\Entities\Price;
 use Paddle\SDK\Entities\Product;
 use Paddle\SDK\Entities\Shared\Totals;
 use Paddle\SDK\Entities\Shared\UnitTotals;
 
-class PricePreviewLineItem implements Entity
+class PricePreviewLineItem
 {
     /**
      * @param PricePreviewDiscounts[] $discounts

--- a/src/Entities/PricingPreview/PricePreviewTotalsFormatted.php
+++ b/src/Entities/PricingPreview/PricePreviewTotalsFormatted.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\PricingPreview;
 
-use Paddle\SDK\Entities\Entity;
-
-class PricePreviewTotalsFormatted implements Entity
+class PricePreviewTotalsFormatted
 {
     public function __construct(
         public string $subtotal,

--- a/src/Entities/PricingPreview/PricePreviewUnitTotalsFormatted.php
+++ b/src/Entities/PricingPreview/PricePreviewUnitTotalsFormatted.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\PricingPreview;
 
-use Paddle\SDK\Entities\Entity;
-
-class PricePreviewUnitTotalsFormatted implements Entity
+class PricePreviewUnitTotalsFormatted
 {
     public function __construct(
         public string $subtotal,

--- a/src/Entities/Product.php
+++ b/src/Entities/Product.php
@@ -20,7 +20,10 @@ use Paddle\SDK\Entities\Shared\TaxCategory;
 
 class Product implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $id,
         public string $name,
         public string|null $description,

--- a/src/Entities/Report.php
+++ b/src/Entities/Report.php
@@ -18,9 +18,11 @@ use Paddle\SDK\Entities\Report\ReportType;
 class Report implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<ReportFilter> $filters
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public ReportStatus $status,
         public int|null $rows,

--- a/src/Entities/ReportCSV.php
+++ b/src/Entities/ReportCSV.php
@@ -13,7 +13,10 @@ namespace Paddle\SDK\Entities;
 
 class ReportCSV implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public readonly string $url,
     ) {
     }

--- a/src/Entities/Subscription.php
+++ b/src/Entities/Subscription.php
@@ -29,9 +29,11 @@ use Paddle\SDK\Entities\Subscription\SubscriptionTimePeriod;
 class Subscription implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<SubscriptionItem> $items
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public SubscriptionStatus $status,
         public string $customerId,

--- a/src/Entities/SubscriptionPreview.php
+++ b/src/Entities/SubscriptionPreview.php
@@ -29,9 +29,11 @@ use Paddle\SDK\Entities\Subscription\SubscriptionTimePeriod;
 class SubscriptionPreview implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<SubscriptionItem> $items
      */
-    public function __construct(
+    protected function __construct(
         public SubscriptionStatus $status,
         public string $customerId,
         public string $addressId,

--- a/src/Entities/SubscriptionTransaction.php
+++ b/src/Entities/SubscriptionTransaction.php
@@ -27,11 +27,13 @@ use Paddle\SDK\Entities\Subscription\SubscriptionTransactionItem;
 class SubscriptionTransaction implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<SubscriptionTransactionItem> $items
      * @param array<TransactionPaymentAttempt>   $payments
      * @param array<SubscriptionAdjustment>      $adjustments
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public StatusTransaction $status,
         public string|null $customerId,

--- a/src/Entities/Transaction.php
+++ b/src/Entities/Transaction.php
@@ -29,12 +29,14 @@ use Paddle\SDK\Entities\Transaction\TransactionTimePeriod;
 class Transaction implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<TransactionItem>           $items
      * @param array<TransactionPaymentAttempt> $payments
      * @param array<TransactionAdjustment>     $adjustments
      * @param array<AvailablePaymentMethods>   $availablePaymentMethods
      */
-    public function __construct(
+    protected function __construct(
         public string $id,
         public StatusTransaction $status,
         public string|null $customerId,

--- a/src/Entities/TransactionData.php
+++ b/src/Entities/TransactionData.php
@@ -13,7 +13,10 @@ namespace Paddle\SDK\Entities;
 
 class TransactionData implements Entity
 {
-    public function __construct(
+    /**
+     * @internal
+     */
+    protected function __construct(
         public string $url,
     ) {
     }

--- a/src/Entities/TransactionPreview.php
+++ b/src/Entities/TransactionPreview.php
@@ -20,10 +20,12 @@ use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPrice;
 class TransactionPreview implements Entity
 {
     /**
+     * @internal
+     *
      * @param array<TransactionItemPreviewWithPrice> $items
      * @param array<AvailablePaymentMethods>         $availablePaymentMethods
      */
-    public function __construct(
+    protected function __construct(
         public string|null $customerId,
         public string|null $addressId,
         public string|null $businessId,


### PR DESCRIPTION
Implementors of `\Paddle\SDK\Entities\Entity` should not be used directly. To prevent this the constructors are now private, and the static factory should be used instead conforming to the shape of the API.

A PHPCS rule has been added to automate this and prevent future breakages. 

BREAKING CHANGE: Makes core Entity constructors private.