### PR TITLE
fix!: Make Report entity naming consistent with SDK

### DIFF
--- a/src/Entities/Report.php
+++ b/src/Entities/Report.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities;
 
-use Paddle\SDK\Entities\Report\ReportFilters;
+use Paddle\SDK\Entities\Report\ReportFilter;
 use Paddle\SDK\Entities\Report\ReportStatus;
 use Paddle\SDK\Entities\Report\ReportType;
 
 class Report implements Entity
 {
     /**
-     * @param array<ReportFilters> $filters
+     * @param array<ReportFilter> $filters
      */
     public function __construct(
         public string $id,
@@ -39,7 +39,7 @@ class Report implements Entity
             status: ReportStatus::from($data['status']),
             rows: $data['rows'] ?? null,
             type: ReportType::from($data['type']),
-            filters: array_map(fn (array $filter): ReportFilters => ReportFilters::from($filter), $data['filters'] ?? []),
+            filters: array_map(fn (array $filter): ReportFilter => ReportFilter::from($filter), $data['filters'] ?? []),
             expiresAt: isset($data['expires_at']) ? DateTime::from($data['expires_at']) : null,
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),

--- a/src/Entities/Report/ReportFilter.php
+++ b/src/Entities/Report/ReportFilter.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Report;
 
-class ReportFilters
+class ReportFilter
 {
     public function __construct(
-        public ReportName $name,
-        public ReportOperator|null $operator,
+        public ReportFilterName $name,
+        public ReportFilterOperator|null $operator,
         public array|string $value,
     ) {
     }
@@ -23,8 +23,8 @@ class ReportFilters
     public static function from(array $data): self
     {
         return new self(
-            name: ReportName::from($data['name']),
-            operator: isset($data['operator']) ? ReportOperator::from($data['operator']) : null,
+            name: ReportFilterName::from($data['name']),
+            operator: isset($data['operator']) ? ReportFilterOperator::from($data['operator']) : null,
             value: $data['value'],
         );
     }

--- a/src/Entities/Report/ReportFilterName.php
+++ b/src/Entities/Report/ReportFilterName.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Report;
 
-enum ReportOperator: string
+enum ReportFilterName: string
 {
-    case Lt = 'lt';
-    case Gte = 'gte';
+    case CollectionMode = 'collection_mode';
+    case CurrencyCode = 'currency_code';
+    case Origin = 'origin';
+    case Status = 'status';
+    case UpdatedAt = 'updated_at';
 }

--- a/src/Entities/Report/ReportFilterOperator.php
+++ b/src/Entities/Report/ReportFilterOperator.php
@@ -11,11 +11,8 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Report;
 
-enum ReportName: string
+enum ReportFilterOperator: string
 {
-    case CollectionMode = 'collection_mode';
-    case CurrencyCode = 'currency_code';
-    case Origin = 'origin';
-    case Status = 'status';
-    case UpdatedAt = 'updated_at';
+    case Lt = 'lt';
+    case Gte = 'gte';
 }

--- a/src/Resources/Reports/Operations/CreateReport.php
+++ b/src/Resources/Reports/Operations/CreateReport.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Resources\Reports\Operations;
 
-use Paddle\SDK\Entities\Report\ReportFilters;
+use Paddle\SDK\Entities\Report\ReportFilter;
 use Paddle\SDK\Entities\Report\ReportType;
 use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
 use Paddle\SDK\FiltersUndefined;
@@ -14,7 +14,7 @@ class CreateReport implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<ReportFilters> $filters
+     * @param array<ReportFilter> $filters
      *
      * @throws InvalidArgumentException
      */
@@ -22,8 +22,8 @@ class CreateReport implements \JsonSerializable
         public readonly ReportType $type,
         public readonly array $filters = [],
     ) {
-        if ($invalid = array_filter($this->filters, fn ($value): bool => ! $value instanceof ReportFilters)) {
-            throw InvalidArgumentException::arrayContainsInvalidTypes('filters', ReportFilters::class, implode(', ', $invalid));
+        if ($invalid = array_filter($this->filters, fn ($value): bool => ! $value instanceof ReportFilter)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('filters', ReportFilter::class, implode(', ', $invalid));
         }
     }
 

--- a/tests/Functional/Resources/Reports/ReportsClientTest.php
+++ b/tests/Functional/Resources/Reports/ReportsClientTest.php
@@ -7,9 +7,9 @@ namespace Paddle\SDK\Tests\Functional\Resources\Reports;
 use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as MockClient;
 use Paddle\SDK\Client;
-use Paddle\SDK\Entities\Report\ReportFilters;
-use Paddle\SDK\Entities\Report\ReportName;
-use Paddle\SDK\Entities\Report\ReportOperator;
+use Paddle\SDK\Entities\Report\ReportFilter;
+use Paddle\SDK\Entities\Report\ReportFilterName;
+use Paddle\SDK\Entities\Report\ReportFilterOperator;
 use Paddle\SDK\Entities\Report\ReportStatus;
 use Paddle\SDK\Entities\Report\ReportType;
 use Paddle\SDK\Environment;
@@ -74,7 +74,7 @@ class ReportsClientTest extends TestCase
         yield 'Create with filters' => [
             new CreateReport(
                 type: ReportType::Transactions,
-                filters: [new ReportFilters(name: ReportName::UpdatedAt, operator: ReportOperator::Lt, value: '2023-12-30')],
+                filters: [new ReportFilter(name: ReportFilterName::UpdatedAt, operator: ReportFilterOperator::Lt, value: '2023-12-30')],
             ),
             new Response(201, body: self::readRawJsonFixture('response/full_entity')),
             self::readRawJsonFixture('request/create_full'),


### PR DESCRIPTION
- ReportFilters -> ReportFilter
- ReportName -> ReportFilterName
- ReportOperator -> ReportFilterOperator

BREAKING CHANGE: Existing usages of the Reports API will fail with class not found. Refactoring to new class names will be required.