### PR TITLE
Fix!: Sync API Spec

### DIFF
--- a/src/Entities/Event/EventTypeName.php
+++ b/src/Entities/Event/EventTypeName.php
@@ -13,6 +13,7 @@ enum EventTypeName: string
     case BusinessCreated = 'business.created';
     case BusinessUpdated = 'business.updated';
     case CustomerCreated = 'customer.created';
+    case CustomerImported = 'customer.imported';
     case CustomerUpdated = 'customer.updated';
     case DiscountCreated = 'discount.created';
     case DiscountImported = 'discount.imported';

--- a/src/Entities/Report/ReportFilterName.php
+++ b/src/Entities/Report/ReportFilterName.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities\Report;
 
 enum ReportFilterName: string
 {
+    case Action = 'action';
     case CollectionMode = 'collection_mode';
     case CurrencyCode = 'currency_code';
     case Origin = 'origin';

--- a/src/Entities/Shared/TransactionPaymentAttempt.php
+++ b/src/Entities/Shared/TransactionPaymentAttempt.php
@@ -15,8 +15,12 @@ use Paddle\SDK\Entities\DateTime;
 
 class TransactionPaymentAttempt
 {
+    /**
+     * @deprecated $storedPaymentMethodId
+     */
     public function __construct(
         public string $paymentAttemptId,
+        public string $paymentMethodId,
         public string $storedPaymentMethodId,
         public string $amount,
         public StatusPaymentAttempt $status,
@@ -31,6 +35,7 @@ class TransactionPaymentAttempt
     {
         return new self(
             $data['payment_attempt_id'],
+            $data['payment_method_id'],
             $data['stored_payment_method_id'],
             $data['amount'],
             StatusPaymentAttempt::from($data['status']),

--- a/src/Resources/Customers/CustomersClient.php
+++ b/src/Resources/Customers/CustomersClient.php
@@ -20,6 +20,7 @@ use Paddle\SDK\Entities\Shared\Status;
 use Paddle\SDK\Exceptions\ApiError;
 use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
 use Paddle\SDK\Resources\Customers\Operations\CreateCustomer;
+use Paddle\SDK\Resources\Customers\Operations\ListCreditBalances;
 use Paddle\SDK\Resources\Customers\Operations\ListCustomers;
 use Paddle\SDK\Resources\Customers\Operations\UpdateCustomer;
 use Paddle\SDK\ResponseParser;
@@ -103,10 +104,10 @@ class CustomersClient
      * @throws ApiError\CustomerApiError On a customer specific API error
      * @throws MalformedResponse         If the API response was not parsable
      */
-    public function creditBalances(string $id): CreditBalanceCollection
+    public function creditBalances(string $id, ListCreditBalances $operation = new ListCreditBalances()): CreditBalanceCollection
     {
         $parser = new ResponseParser(
-            $this->client->getRaw("/customers/{$id}/credit-balances"),
+            $this->client->getRaw("/customers/{$id}/credit-balances", $operation),
         );
 
         return CreditBalanceCollection::from($parser->getData());

--- a/src/Resources/Customers/Operations/ListCreditBalances.php
+++ b/src/Resources/Customers/Operations/ListCreditBalances.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Customers\Operations;
+
+use Paddle\SDK\Entities\Shared\CurrencyCode;
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
+use Paddle\SDK\HasParameters;
+
+class ListCreditBalances implements HasParameters
+{
+    /**
+     * @param array<CurrencyCode> $currencyCodes
+     *
+     * @throws InvalidArgumentException On invalid array contents
+     */
+    public function __construct(
+        private readonly array $currencyCodes = [],
+    ) {
+        if ($invalid = array_filter($this->currencyCodes, fn ($value): bool => ! $value instanceof CurrencyCode)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('currencyCodes', CurrencyCode::class, implode(', ', $invalid));
+        }
+    }
+
+    public function getParameters(): array
+    {
+        $enumStringify = fn ($enum) => $enum->value;
+
+        return array_filter([
+                'currency_code' => implode(',', array_map($enumStringify, $this->currencyCodes)),
+            ]);
+    }
+}

--- a/src/Resources/Notifications/Operations/ListNotifications.php
+++ b/src/Resources/Notifications/Operations/ListNotifications.php
@@ -6,24 +6,32 @@ namespace Paddle\SDK\Resources\Notifications\Operations;
 
 use Paddle\SDK\Entities\DateTime;
 use Paddle\SDK\Entities\Notification\NotificationStatus;
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
 use Paddle\SDK\HasParameters;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 
 class ListNotifications implements HasParameters
 {
     /**
-     * @param array<string>             $notificationSettingId
-     * @param array<NotificationStatus> $status
+     * @param array<string>             $notificationSettingIds
+     * @param array<NotificationStatus> $statuses
      */
     public function __construct(
         private readonly Pager|null $pager = null,
-        private readonly array $notificationSettingId = [],
+        private readonly array $notificationSettingIds = [],
         private readonly string|null $search = null,
-        private readonly array $status = [],
+        private readonly array $statuses = [],
         private readonly string|null $filter = null,
         private readonly \DateTimeInterface|null $to = null,
         private readonly \DateTimeInterface|null $from = null,
     ) {
+        if ($invalid = array_filter($this->notificationSettingIds, fn ($value): bool => ! is_string($value))) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('notificationSettingIds', 'string', implode(', ', $invalid));
+        }
+
+        if ($invalid = array_filter($this->statuses, fn ($value): bool => ! $value instanceof NotificationStatus)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('statuses', NotificationStatus::class, implode(', ', $invalid));
+        }
     }
 
     public function getParameters(): array
@@ -33,9 +41,9 @@ class ListNotifications implements HasParameters
         return array_merge(
             $this->pager?->getParameters() ?? [],
             array_filter([
-                'notification_setting_id' => implode(',', $this->notificationSettingId),
+                'notification_setting_id' => implode(',', $this->notificationSettingIds),
                 'search' => $this->search,
-                'status' => implode(',', array_map($enumStringify, $this->status)),
+                'status' => implode(',', array_map($enumStringify, $this->statuses)),
                 'filter' => $this->filter,
                 'to' => isset($this->to) ? DateTime::from($this->to)?->format() : null,
                 'from' => isset($this->from) ? DateTime::from($this->from)?->format() : null,

--- a/src/Resources/Subscriptions/Operations/CreateOneTimeCharge.php
+++ b/src/Resources/Subscriptions/Operations/CreateOneTimeCharge.php
@@ -22,6 +22,7 @@ class CreateOneTimeCharge implements \JsonSerializable
         public readonly SubscriptionEffectiveFrom $effectiveFrom,
         public readonly array $items,
         public readonly SubscriptionOnPaymentFailure|Undefined $onPaymentFailure = new Undefined(),
+        public readonly string|Undefined $receiptData = new Undefined(),
     ) {
     }
 
@@ -31,6 +32,7 @@ class CreateOneTimeCharge implements \JsonSerializable
             'effective_from' => $this->effectiveFrom,
             'items' => $this->items,
             'on_payment_failure' => $this->onPaymentFailure,
+            'receipt_data' => $this->receiptData,
         ]);
     }
 }

--- a/src/Resources/Subscriptions/Operations/PreviewOneTimeCharge.php
+++ b/src/Resources/Subscriptions/Operations/PreviewOneTimeCharge.php
@@ -22,6 +22,7 @@ class PreviewOneTimeCharge implements \JsonSerializable
         public readonly SubscriptionEffectiveFrom $effectiveFrom,
         public readonly array $items,
         public readonly SubscriptionOnPaymentFailure|Undefined $onPaymentFailure = new Undefined(),
+        public readonly string|Undefined $receiptData = new Undefined(),
     ) {
     }
 
@@ -31,6 +32,7 @@ class PreviewOneTimeCharge implements \JsonSerializable
             'effective_from' => $this->effectiveFrom,
             'items' => $this->items,
             'on_payment_failure' => $this->onPaymentFailure,
+            'receipt_data' => $this->receiptData,
         ]);
     }
 }

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -406,6 +406,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "afa07161-601d-4a65-8c1a-6993ae1ae027",
+                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                         "stored_payment_method_id": "d3218a38-1cff-44a7-8a47-6a809a5ae9ad"
                     }
                 ],
@@ -737,6 +738,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "afa07161-601d-4a65-8c1a-6993ae1ae027",
+                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                         "stored_payment_method_id": "d3218a38-1cff-44a7-8a47-6a809a5ae9ad"
                     }
                 ],
@@ -1068,6 +1070,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "afa07161-601d-4a65-8c1a-6993ae1ae027",
+                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                         "stored_payment_method_id": "d3218a38-1cff-44a7-8a47-6a809a5ae9ad"
                     }
                 ],
@@ -2408,6 +2411,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "0bec49bd-dd4d-45e3-a91e-46992b09c5e2",
+                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                         "stored_payment_method_id": "8009a718-30f7-4718-a7f6-4d3fdecf559b"
                     }
                 ],
@@ -2753,6 +2757,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "0bec49bd-dd4d-45e3-a91e-46992b09c5e2",
+                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                         "stored_payment_method_id": "8009a718-30f7-4718-a7f6-4d3fdecf559b"
                     }
                 ],

--- a/tests/Functional/Resources/Notifications/NotificationsClientTest.php
+++ b/tests/Functional/Resources/Notifications/NotificationsClientTest.php
@@ -79,13 +79,13 @@ class NotificationsClientTest extends TestCase
         ];
 
         yield 'Notification Setting ID Filtered' => [
-            new ListNotifications(notificationSettingId: ['nftset_01h83xenpcfjyhkqr4x214m02']),
+            new ListNotifications(notificationSettingIds: ['nftset_01h83xenpcfjyhkqr4x214m02']),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/notifications?notification_setting_id=nftset_01h83xenpcfjyhkqr4x214m02', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Multiple Notification Setting ID Filtered' => [
-            new ListNotifications(notificationSettingId: ['nftset_01h83xenpcfjyhkqr4x214m02', 'nftset_01h8brhckjd6qk4n7e4py2340t']),
+            new ListNotifications(notificationSettingIds: ['nftset_01h83xenpcfjyhkqr4x214m02', 'nftset_01h8brhckjd6qk4n7e4py2340t']),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf(
                 '%s/notifications?notification_setting_id=nftset_01h83xenpcfjyhkqr4x214m02,nftset_01h8brhckjd6qk4n7e4py2340t',
@@ -94,13 +94,13 @@ class NotificationsClientTest extends TestCase
         ];
 
         yield 'NotificationStatus Filtered' => [
-            new ListNotifications(status: [NotificationStatus::Delivered]),
+            new ListNotifications(statuses: [NotificationStatus::Delivered]),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/notifications?status=delivered', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Multiple NotificationStatus Filtered' => [
-            new ListNotifications(status: [NotificationStatus::Delivered, NotificationStatus::NotAttempted]),
+            new ListNotifications(statuses: [NotificationStatus::Delivered, NotificationStatus::NotAttempted]),
             new Response(200, body: self::readRawJsonFixture('response/list_default')),
             sprintf('%s/notifications?status=delivered,not_attempted', Environment::SANDBOX->baseUrl()),
         ];

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -906,6 +906,7 @@
       "payments": [
         {
           "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+          "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
           "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
           "amount": "40000",
           "status": "captured",

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
@@ -892,6 +892,7 @@
             "payments": [
                 {
                     "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+                    "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                     "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
                     "amount": "40000",
                     "status": "captured",

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
@@ -892,6 +892,7 @@
             "payments": [
                 {
                     "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+                    "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
                     "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
                     "amount": "40000",
                     "status": "captured",


### PR DESCRIPTION
- `EventTypeName` enum now supports `customer.imported`
- `ReportFilterName` enum now supports `action`
- Added  `payment_method_id` to Transaction.payments entity and deprecated `stored_payment_method_id`
- List Credit Balances for a Customer now supports filtering by `currency_code`
- Breaking change: ListNotification operation uses same naming conventions as other operations
- Create/Preview a one-time charge for a subscription now supports `receipt_data`