### PR TITLE
Refactor webhook verification process in Verifier class

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,14 @@ The SDK includes a helper class to verify webhook signatures sent by Notificatio
 ``` php
 use Paddle\SDK\Notifications\Secret;
 use Paddle\SDK\Notifications\Verifier;
+use Paddle\SDK\Notifications\PaddleSignature;
+
+$payload = @file_get_contents('php://input');
+$signatureHeader = $_SERVER[PaddleSignature::HEADER];
 
 (new Verifier())->verify(
-    $request,
+    $payload,
+    $signatureHeader,
     new Secret('WEBHOOK_SECRET_KEY')
 );
 ```

--- a/src/Notifications/Verifier.php
+++ b/src/Notifications/Verifier.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Notifications;
 
-use Psr\Http\Message\RequestInterface;
-
 final class Verifier
 {
     public function __construct(
@@ -13,23 +11,16 @@ final class Verifier
     ) {
     }
 
-    public function verify(RequestInterface $request, Secret ...$secrets): bool
+    public function verify(string $payload, string $signatureHeader, Secret ...$secrets): bool
     {
-        $signatureData = $request->getHeader(PaddleSignature::HEADER);
-        if ($signatureData === []) {
-            return false;
-        }
-
-        $signature = PaddleSignature::parse($signatureData[0]);
+        $signature = PaddleSignature::parse($signatureHeader);
 
         if ($this->maximumVariance > 0 && \time() > $signature->timestamp + $this->maximumVariance) {
             return false;
         }
 
-        $request->getBody()->rewind();
-
         return $signature->verify(
-            (string) $request->getBody(),
+            $payload,
             ...$secrets,
         );
     }

--- a/tests/Unit/Notifications/VerifierTest.php
+++ b/tests/Unit/Notifications/VerifierTest.php
@@ -32,6 +32,9 @@ class VerifierTest extends TestCase
             new Secret('pdl_ntf_01hbpjmytsa32fhr36nqgc3kgb_WvRO0eL4Bj9rgYYIBZY6wZhG4EHy9jzh'),
         ];
 
-        self::assertTrue((new Verifier(null))->verify($request, ...$secrets));
+        $payload = $request->getBody()->getContents();
+        $signatureHeader = $request->getHeader(PaddleSignature::HEADER)[0];
+
+        self::assertTrue((new Verifier(null))->verify($payload, $signatureHeader, ...$secrets));
     }
 }


### PR DESCRIPTION
With these modifications, developers no longer need to depend on their requests being PSR HTTP compliant. Many codebases and frameworks do not come with built-in support, so this will increase flexibility.