### PR TITLE
fix!: Consistent naming for Adjustment totals obj

### DIFF
--- a/src/Entities/Adjustment.php
+++ b/src/Entities/Adjustment.php
@@ -14,9 +14,9 @@ namespace Paddle\SDK\Entities;
 use Paddle\SDK\Entities\Adjustment\AdjustmentItem;
 use Paddle\SDK\Entities\Shared\Action;
 use Paddle\SDK\Entities\Shared\AdjustmentStatus;
+use Paddle\SDK\Entities\Shared\AdjustmentTotals;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\PayoutTotalsAdjustment;
-use Paddle\SDK\Entities\Shared\TotalAdjustments;
 
 class Adjustment implements Entity
 {
@@ -36,7 +36,7 @@ class Adjustment implements Entity
         public CurrencyCode $currencyCode,
         public AdjustmentStatus $status,
         public array $items,
-        public TotalAdjustments $totals,
+        public AdjustmentTotals $totals,
         public PayoutTotalsAdjustment|null $payoutTotals,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface|null $updatedAt,
@@ -56,7 +56,7 @@ class Adjustment implements Entity
             currencyCode: CurrencyCode::from($data['currency_code']),
             status: AdjustmentStatus::from($data['status']),
             items: array_map(fn (array $item) => AdjustmentItem::from($item), $data['items']),
-            totals: TotalAdjustments::from($data['totals']),
+            totals: AdjustmentTotals::from($data['totals']),
             payoutTotals: isset($data['payout_totals']) ? PayoutTotalsAdjustment::from($data['payout_totals']) : null,
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),

--- a/src/Entities/Shared/AdjustmentTotals.php
+++ b/src/Entities/Shared/AdjustmentTotals.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Shared;
 
-class TotalAdjustments
+class AdjustmentTotals
 {
     public function __construct(
         public string $subtotal,

--- a/src/Entities/Subscription/SubscriptionAdjustmentPreview.php
+++ b/src/Entities/Subscription/SubscriptionAdjustmentPreview.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Subscription;
 
-use Paddle\SDK\Entities\Shared\TotalAdjustments;
+use Paddle\SDK\Entities\Shared\AdjustmentTotals;
 
 class SubscriptionAdjustmentPreview
 {
@@ -14,7 +14,7 @@ class SubscriptionAdjustmentPreview
     public function __construct(
         public string $transactionId,
         public array $items,
-        public TotalAdjustments $totals,
+        public AdjustmentTotals $totals,
     ) {
     }
 
@@ -23,7 +23,7 @@ class SubscriptionAdjustmentPreview
         return new self(
             transactionId: $data['transaction_id'],
             items: array_map(fn (array $item) => SubscriptionAdjustmentItem::from($item), $data['items']),
-            totals: TotalAdjustments::from($data['totals']),
+            totals: AdjustmentTotals::from($data['totals']),
         );
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Any existing typing for TotalAdjustments will cause  a class not found error until refactored to AdjustmentTotals