### PR TITLE
Fix!: Update resume subscription options

### DIFF
--- a/src/Entities/Subscription/SubscriptionResumeEffectiveFrom.php
+++ b/src/Entities/Subscription/SubscriptionResumeEffectiveFrom.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Subscription;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SubscriptionResumeEffectiveFrom Immediately()
+ */
+class SubscriptionResumeEffectiveFrom extends PaddleEnum
+{
+    private const Immediately = 'immediately';
+}

--- a/src/Resources/Subscriptions/Operations/ResumeSubscription.php
+++ b/src/Resources/Subscriptions/Operations/ResumeSubscription.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Paddle\SDK\Resources\Subscriptions\Operations;
 
 use Paddle\SDK\Entities\DateTime;
-use Paddle\SDK\Entities\Subscription\SubscriptionEffectiveFrom;
+use Paddle\SDK\Entities\Subscription\SubscriptionResumeEffectiveFrom;
 
 class ResumeSubscription implements \JsonSerializable
 {
     public function __construct(
-        public readonly SubscriptionEffectiveFrom|\DateTimeInterface|null $effectiveFrom = null,
+        public readonly SubscriptionResumeEffectiveFrom|\DateTimeInterface|null $effectiveFrom = null,
     ) {
     }
 

--- a/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
+++ b/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
@@ -14,6 +14,7 @@ use Paddle\SDK\Entities\Subscription\SubscriptionEffectiveFrom;
 use Paddle\SDK\Entities\Subscription\SubscriptionItems;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
+use Paddle\SDK\Entities\Subscription\SubscriptionResumeEffectiveFrom;
 use Paddle\SDK\Entities\Subscription\SubscriptionScheduledChangeAction;
 use Paddle\SDK\Entities\Subscription\SubscriptionStatus;
 use Paddle\SDK\Environment;
@@ -340,7 +341,7 @@ class SubscriptionsClientTest extends TestCase
         ];
 
         yield 'Update Single As Enum' => [
-            new ResumeSubscription(SubscriptionEffectiveFrom::NextBillingPeriod()),
+            new ResumeSubscription(SubscriptionResumeEffectiveFrom::Immediately()),
             new Response(200, body: self::readRawJsonFixture('response/full_entity')),
             self::readRawJsonFixture('request/resume_single_as_enum'),
         ];

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/resume_single_as_enum.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/resume_single_as_enum.json
@@ -1,3 +1,3 @@
 {
-    "effective_from": "next_billing_period"
+    "effective_from": "immediately"
 }


### PR DESCRIPTION
Fixed:
-  Update resume subscription `effective_from` option to accept RFC 3339 datetime or `immediately`