### PR TITLE
Fix!: Entities should use array instead of collections

### DIFF
--- a/src/Entities/NotificationSetting.php
+++ b/src/Entities/NotificationSetting.php
@@ -11,13 +11,14 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities;
 
-use Paddle\SDK\Entities\Collections\EventTypeCollection;
 use Paddle\SDK\Entities\NotificationSetting\NotificationSettingType;
 
 class NotificationSetting implements Entity
 {
     /**
      * @internal
+     *
+     * @param array<EventType> $subscribedEvents
      */
     protected function __construct(
         public string $id,
@@ -27,7 +28,7 @@ class NotificationSetting implements Entity
         public bool $active,
         public int $apiVersion,
         public bool $includeSensitiveFields,
-        public EventTypeCollection $subscribedEvents,
+        public array $subscribedEvents,
         public string $endpointSecretKey,
     ) {
     }
@@ -35,15 +36,15 @@ class NotificationSetting implements Entity
     public static function from(array $data): self
     {
         return new self(
-            $data['id'],
-            $data['description'],
-            NotificationSettingType::from($data['type']),
-            $data['destination'],
-            $data['active'],
-            $data['api_version'],
-            $data['include_sensitive_fields'],
-            EventTypeCollection::from($data['subscribed_events']),
-            $data['endpoint_secret_key'],
+            id: $data['id'],
+            description: $data['description'],
+            type: NotificationSettingType::from($data['type']),
+            destination: $data['destination'],
+            active: $data['active'],
+            apiVersion: $data['api_version'],
+            includeSensitiveFields: $data['include_sensitive_fields'],
+            subscribedEvents: array_map(fn (array $eventType): EventType => EventType::from($eventType), $data['subscribed_events'] ?? []),
+            endpointSecretKey: $data['endpoint_secret_key'],
         );
     }
 }

--- a/src/Entities/Product.php
+++ b/src/Entities/Product.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities;
 
-use Paddle\SDK\Entities\Collections\PriceCollection;
 use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\ImportMeta;
@@ -22,6 +21,8 @@ class Product implements Entity
 {
     /**
      * @internal
+     *
+     * @param array<Price> $prices
      */
     protected function __construct(
         public string $id,
@@ -34,7 +35,7 @@ class Product implements Entity
         public Status $status,
         public \DateTimeInterface|null $createdAt,
         public ImportMeta|null $importMeta,
-        public PriceCollection $prices,
+        public array $prices,
     ) {
     }
 
@@ -51,7 +52,7 @@ class Product implements Entity
             status: Status::from($data['status']),
             createdAt: isset($data['created_at']) ? DateTime::from($data['created_at']) : null,
             importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
-            prices: PriceCollection::from($data['prices'] ?? []),
+            prices: array_map(fn (array $price): Price => Price::from($price), $data['prices'] ?? []),
         );
     }
 }


### PR DESCRIPTION
Fixed:
- Updated couple of entities that were using collections instead of `array<Entity>`