### PR TITLE
Feat: New error code for payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [1.1.0] - 2024-04-30
+
+### Added
+
+- New error code for payments `declined_not_retryable`, see [related changelog](https://developer.paddle.com/changelog/2024/declined-not-retryable-error-code?utm_source=dx&utm_medium=paddle-php-sdk).
+
 ## [1.0.1] - 2024-03-13
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Paddle.com Market Limited
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.0.1';
+    private const SDK_VERSION = '1.1.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;

--- a/src/Entities/Shared/ErrorCode.php
+++ b/src/Entities/Shared/ErrorCode.php
@@ -20,6 +20,7 @@ use Paddle\SDK\PaddleEnum;
  * @method static ErrorCode BlockedCard()
  * @method static ErrorCode Canceled()
  * @method static ErrorCode Declined()
+ * @method static ErrorCode DeclinedNotRetryable()
  * @method static ErrorCode ExpiredCard()
  * @method static ErrorCode Fraud()
  * @method static ErrorCode InvalidAmount()
@@ -40,6 +41,7 @@ final class ErrorCode extends PaddleEnum
     private const BlockedCard = 'blocked_card';
     private const Canceled = 'canceled';
     private const Declined = 'declined';
+    private const DeclinedNotRetryable = 'declined_not_retryable';
     private const ExpiredCard = 'expired_card';
     private const Fraud = 'fraud';
     private const InvalidAmount = 'invalid_amount';


### PR DESCRIPTION
## Added

- New error code for payments `declined_not_retryable`, see [related changelog](https://developer.paddle.com/changelog/2024/declined-not-retryable-error-code?utm_source=dx&utm_medium=paddle-php-sdk).
