### PR TITLE
Feature: Support disposition query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Added `product` to `subscription.items[]`, see [related changelog](https://developer.paddle.com/changelog/2024/subscription-items-product?utm_source=dx&utm_medium=paddle-php-sdk)
 - Added `import_meta` to `transaction`
 - Support for `createdAt` and `updatedAt` on Subscription notification prices
+- `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
 
 ## [1.1.2] - 2024-08-23
 

--- a/src/Entities/Shared/Disposition.php
+++ b/src/Entities/Shared/Disposition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static Disposition Attachment()
+ * @method static Disposition Inline()
+ */
+final class Disposition extends PaddleEnum
+{
+    private const Attachment = 'attachment';
+    private const Inline = 'inline';
+}

--- a/src/Resources/Transactions/Operations/GetTransactionInvoice.php
+++ b/src/Resources/Transactions/Operations/GetTransactionInvoice.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations;
+
+use Paddle\SDK\Entities\Shared\Disposition;
+use Paddle\SDK\HasParameters;
+
+class GetTransactionInvoice implements HasParameters
+{
+    public function __construct(
+        private readonly Disposition|null $disposition = null,
+    ) {
+    }
+
+    public function getParameters(): array
+    {
+        return array_filter([
+            'disposition' => $this->disposition?->getValue(),
+        ]);
+    }
+}

--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -14,7 +14,6 @@ namespace Paddle\SDK\Resources\Transactions;
 use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\Collections\TransactionCollection;
-use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Transaction;
 use Paddle\SDK\Entities\TransactionData;
 use Paddle\SDK\Entities\TransactionPreview;
@@ -22,6 +21,7 @@ use Paddle\SDK\Exceptions\ApiError;
 use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
 use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
 use Paddle\SDK\Resources\Transactions\Operations\PreviewTransaction;
@@ -129,12 +129,10 @@ class TransactionsClient
      * @throws ApiError\TransactionApiError On a transaction specific API error
      * @throws MalformedResponse            If the API response was not parsable
      */
-    public function getInvoicePDF(string $id, Disposition|null $disposition = null): TransactionData
+    public function getInvoicePDF(string $id, GetTransactionInvoice $getOperation = new GetTransactionInvoice()): TransactionData
     {
-        $params = $disposition === null ? [] : ['disposition' => $disposition->getValue()];
-
         $parser = new ResponseParser(
-            $this->client->getRaw("/transactions/{$id}/invoice", $params),
+            $this->client->getRaw("/transactions/{$id}/invoice", $getOperation),
         );
 
         return TransactionData::from($parser->getData());

--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -14,6 +14,7 @@ namespace Paddle\SDK\Resources\Transactions;
 use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\Collections\TransactionCollection;
+use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Transaction;
 use Paddle\SDK\Entities\TransactionData;
 use Paddle\SDK\Entities\TransactionPreview;
@@ -128,10 +129,12 @@ class TransactionsClient
      * @throws ApiError\TransactionApiError On a transaction specific API error
      * @throws MalformedResponse            If the API response was not parsable
      */
-    public function getInvoicePDF(string $id): TransactionData
+    public function getInvoicePDF(string $id, Disposition|null $disposition = null): TransactionData
     {
+        $params = $disposition === null ? [] : ['disposition' => $disposition->getValue()];
+
         $parser = new ResponseParser(
-            $this->client->getRaw("/transactions/{$id}/invoice"),
+            $this->client->getRaw("/transactions/{$id}/invoice", $params),
         );
 
         return TransactionData::from($parser->getData());

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -30,6 +30,7 @@ use Paddle\SDK\Resources\Shared\Operations\List\Comparator;
 use Paddle\SDK\Resources\Shared\Operations\List\DateComparison;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
@@ -531,12 +532,12 @@ class TransactionsClientTest extends TestCase
      */
     public function get_invoice_pdf_hits_expected_uri(
         string $id,
-        Disposition|null $disposition,
+        GetTransactionInvoice $getOperation,
         ResponseInterface $response,
         string $expectedUri,
     ): void {
         $this->mockClient->addResponse($response);
-        $this->client->transactions->getInvoicePDF($id, $disposition);
+        $this->client->transactions->getInvoicePDF($id, $getOperation);
         $request = $this->mockClient->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);
@@ -548,21 +549,21 @@ class TransactionsClientTest extends TestCase
     {
         yield 'Default' => [
             'txn_01hen7bxc1p8ep4yk7n5jbzk9r',
-            null,
+            new GetTransactionInvoice(),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r/invoice', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Disposition Inline' => [
             'txn_02hen7bxc1p8ep4yk7n5jbzk9r',
-            Disposition::Inline(),
+            new GetTransactionInvoice(Disposition::Inline()),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_02hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=inline', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Disposition Attachment' => [
             'txn_03hen7bxc1p8ep4yk7n5jbzk9r',
-            Disposition::Attachment(),
+            new GetTransactionInvoice(Disposition::Attachment()),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_03hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=attachment', Environment::SANDBOX->baseUrl()),
         ];

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -11,6 +11,7 @@ use Paddle\SDK\Entities\Shared\BillingDetails;
 use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Shared\Interval;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
@@ -529,11 +530,13 @@ class TransactionsClientTest extends TestCase
      * @dataProvider getInvoicePDFOperationsProvider
      */
     public function get_invoice_pdf_hits_expected_uri(
+        string $id,
+        Disposition|null $disposition,
         ResponseInterface $response,
         string $expectedUri,
     ): void {
         $this->mockClient->addResponse($response);
-        $this->client->transactions->getInvoicePDF('txn_01hen7bxc1p8ep4yk7n5jbzk9r');
+        $this->client->transactions->getInvoicePDF($id, $disposition);
         $request = $this->mockClient->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);
@@ -544,8 +547,24 @@ class TransactionsClientTest extends TestCase
     public static function getInvoicePDFOperationsProvider(): \Generator
     {
         yield 'Default' => [
+            'txn_01hen7bxc1p8ep4yk7n5jbzk9r',
+            null,
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r/invoice', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'Disposition Inline' => [
+            'txn_02hen7bxc1p8ep4yk7n5jbzk9r',
+            Disposition::Inline(),
+            new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
+            sprintf('%s/transactions/txn_02hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=inline', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'Disposition Attachment' => [
+            'txn_03hen7bxc1p8ep4yk7n5jbzk9r',
+            Disposition::Attachment(),
+            new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
+            sprintf('%s/transactions/txn_03hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=attachment', Environment::SANDBOX->baseUrl()),
         ];
     }
 }


### PR DESCRIPTION
### Added
- `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)