### PR TITLE
Feature: API Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Added `import_meta` to `transaction`
 - Support for `createdAt` and `updatedAt` on Subscription notification prices
 - Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
+- `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Support for `createdAt` and `updatedAt` on Subscription notification prices
 - Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
 - `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
+- Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
+- Support notification settings `active` filter
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Support for `createdAt` and `updatedAt` on Subscription notification prices
 - Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
 
+### Fixed
+
+- `PreviewPrice` operation no longer allows empty `items`
+
 ## [1.1.2] - 2024-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Added `product` to `subscription.items[]`, see [related changelog](https://developer.paddle.com/changelog/2024/subscription-items-product?utm_source=dx&utm_medium=paddle-php-sdk)
 - Added `import_meta` to `transaction`
 - Support for `createdAt` and `updatedAt` on Subscription notification prices
+- Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
 
 ## [1.1.2] - 2024-08-23
 

--- a/src/Entities/Shared/Disposition.php
+++ b/src/Entities/Shared/Disposition.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static Disposition Attachment()
+ * @method static Disposition Inline()
+ */
+final class Disposition extends PaddleEnum
+{
+    private const Attachment = 'attachment';
+    private const Inline = 'inline';
+}

--- a/src/Entities/Shared/Disposition.php
+++ b/src/Entities/Shared/Disposition.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
 namespace Paddle\SDK\Entities\Shared;
 
 use Paddle\SDK\PaddleEnum;

--- a/src/Entities/Subscription/SubscriptionNonCatalogPrice.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogPrice.php
@@ -15,6 +15,7 @@ use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
 class SubscriptionNonCatalogPrice
@@ -31,6 +32,8 @@ class SubscriptionNonCatalogPrice
         public array $unitPriceOverrides,
         public PriceQuantity $quantity,
         public CustomData|null $customData,
+        public TimePeriod|null $billingCycle = null,
+        public TimePeriod|null $trialPeriod = null,
     ) {
     }
 }

--- a/src/Entities/Subscription/SubscriptionNonCatalogPriceWithProduct.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogPriceWithProduct.php
@@ -15,6 +15,7 @@ use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
 class SubscriptionNonCatalogPriceWithProduct
@@ -31,6 +32,8 @@ class SubscriptionNonCatalogPriceWithProduct
         public array $unitPriceOverrides,
         public PriceQuantity $quantity,
         public CustomData|null $customData,
+        public TimePeriod|null $billingCycle = null,
+        public TimePeriod|null $trialPeriod = null,
     ) {
     }
 }

--- a/src/Exceptions/SdkExceptions/InvalidArgumentException.php
+++ b/src/Exceptions/SdkExceptions/InvalidArgumentException.php
@@ -8,6 +8,11 @@ use Paddle\SDK\Exceptions\SdkException;
 
 class InvalidArgumentException extends SdkException
 {
+    public static function arrayIsEmpty(string $field): self
+    {
+        return new self(sprintf('%s cannot be empty', $field));
+    }
+
     public static function arrayContainsInvalidTypes(string $field, string $expectedType, string $given): self
     {
         return new self(sprintf(

--- a/src/Resources/NotificationSettings/NotificationSettingsClient.php
+++ b/src/Resources/NotificationSettings/NotificationSettingsClient.php
@@ -13,10 +13,12 @@ namespace Paddle\SDK\Resources\NotificationSettings;
 
 use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Collections\NotificationSettingCollection;
+use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\NotificationSetting;
 use Paddle\SDK\Exceptions\ApiError;
 use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
 use Paddle\SDK\Resources\NotificationSettings\Operations\CreateNotificationSetting;
+use Paddle\SDK\Resources\NotificationSettings\Operations\ListNotificationSettings;
 use Paddle\SDK\Resources\NotificationSettings\Operations\UpdateNotificationSetting;
 use Paddle\SDK\ResponseParser;
 
@@ -31,14 +33,15 @@ class NotificationSettingsClient
      * @throws ApiError          On a generic API error
      * @throws MalformedResponse If the API response was not parsable
      */
-    public function list(): NotificationSettingCollection
+    public function list(ListNotificationSettings $listOperation = new ListNotificationSettings()): NotificationSettingCollection
     {
         $parser = new ResponseParser(
-            $this->client->getRaw('notification-settings'),
+            $this->client->getRaw('notification-settings', $listOperation),
         );
 
         return NotificationSettingCollection::from(
             $parser->getData(),
+            new Paginator($this->client, $parser->getPagination(), NotificationSettingCollection::class),
         );
     }
 

--- a/src/Resources/NotificationSettings/Operations/ListNotificationSettings.php
+++ b/src/Resources/NotificationSettings/Operations/ListNotificationSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\NotificationSettings\Operations;
+
+use Paddle\SDK\HasParameters;
+use Paddle\SDK\Resources\Shared\Operations\List\Pager;
+
+class ListNotificationSettings implements HasParameters
+{
+    public function __construct(
+        private readonly Pager|null $pager = null,
+        private readonly bool|null $active = null,
+    ) {
+    }
+
+    public function getParameters(): array
+    {
+        return array_merge(
+            $this->pager?->getParameters() ?? [],
+            array_filter([
+                'active' => isset($this->active) ? ($this->active ? 'true' : 'false') : null,
+            ]),
+        );
+    }
+}

--- a/src/Resources/PricingPreviews/Operations/PreviewPrice.php
+++ b/src/Resources/PricingPreviews/Operations/PreviewPrice.php
@@ -7,6 +7,7 @@ namespace Paddle\SDK\Resources\PricingPreviews\Operations;
 use Paddle\SDK\Entities\PricingPreview\PricePreviewItem;
 use Paddle\SDK\Entities\Shared\AddressPreview;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Undefined;
 
@@ -27,6 +28,13 @@ class PreviewPrice implements \JsonSerializable
         public readonly AddressPreview|Undefined|null $address = new Undefined(),
         public readonly string|Undefined|null $customerIpAddress = new Undefined(),
     ) {
+        if (count($this->items) === 0) {
+            throw InvalidArgumentException::arrayIsEmpty('items');
+        }
+
+        if ($invalid = array_filter($this->items, fn ($value): bool => ! $value instanceof PricePreviewItem)) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('items', PricePreviewItem::class, implode(', ', $invalid));
+        }
     }
 
     public function jsonSerialize(): array

--- a/src/Resources/Subscriptions/Operations/PreviewUpdateSubscription.php
+++ b/src/Resources/Subscriptions/Operations/PreviewUpdateSubscription.php
@@ -10,6 +10,7 @@ use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Subscription\SubscriptionItems;
+use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
 use Paddle\SDK\FiltersUndefined;
@@ -21,7 +22,7 @@ class PreviewUpdateSubscription implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems> $items
+     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly string|Undefined $customerId = new Undefined(),

--- a/src/Resources/Subscriptions/Operations/UpdateSubscription.php
+++ b/src/Resources/Subscriptions/Operations/UpdateSubscription.php
@@ -10,6 +10,7 @@ use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Subscription\SubscriptionItems;
+use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
 use Paddle\SDK\FiltersUndefined;
@@ -21,7 +22,7 @@ class UpdateSubscription implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems> $items
+     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly string|Undefined $customerId = new Undefined(),

--- a/src/Resources/Transactions/Operations/GetTransactionInvoice.php
+++ b/src/Resources/Transactions/Operations/GetTransactionInvoice.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations;
+
+use Paddle\SDK\Entities\Shared\Disposition;
+use Paddle\SDK\HasParameters;
+
+class GetTransactionInvoice implements HasParameters
+{
+    public function __construct(
+        private readonly Disposition|null $disposition = null,
+    ) {
+    }
+
+    public function getParameters(): array
+    {
+        return array_filter([
+            'disposition' => $this->disposition?->getValue(),
+        ]);
+    }
+}

--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -14,7 +14,6 @@ namespace Paddle\SDK\Resources\Transactions;
 use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\Collections\TransactionCollection;
-use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Transaction;
 use Paddle\SDK\Entities\TransactionData;
 use Paddle\SDK\Entities\TransactionPreview;
@@ -22,6 +21,7 @@ use Paddle\SDK\Exceptions\ApiError;
 use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
 use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
 use Paddle\SDK\Resources\Transactions\Operations\PreviewTransaction;
@@ -129,12 +129,10 @@ class TransactionsClient
      * @throws ApiError\TransactionApiError On a transaction specific API error
      * @throws MalformedResponse            If the API response was not parsable
      */
-    public function getInvoicePDF(string $id, Disposition|null $disposition = null): TransactionData
+    public function getInvoicePDF(string $id, GetTransactionInvoice $getOperation = new GetTransactionInvoice()): TransactionData
     {
-        $params = $disposition === null ? [] : ['disposition' => $disposition->getValue()];
-
         $parser = new ResponseParser(
-            $this->client->getRaw("/transactions/{$id}/invoice", $params),
+            $this->client->getRaw("/transactions/{$id}/invoice", $getOperation),
         );
 
         return TransactionData::from($parser->getData());

--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -14,6 +14,7 @@ namespace Paddle\SDK\Resources\Transactions;
 use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\Collections\TransactionCollection;
+use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Transaction;
 use Paddle\SDK\Entities\TransactionData;
 use Paddle\SDK\Entities\TransactionPreview;
@@ -128,10 +129,12 @@ class TransactionsClient
      * @throws ApiError\TransactionApiError On a transaction specific API error
      * @throws MalformedResponse            If the API response was not parsable
      */
-    public function getInvoicePDF(string $id): TransactionData
+    public function getInvoicePDF(string $id, Disposition|null $disposition = null): TransactionData
     {
+        $params = $disposition === null ? [] : ['disposition' => $disposition->getValue()];
+
         $parser = new ResponseParser(
-            $this->client->getRaw("/transactions/{$id}/invoice"),
+            $this->client->getRaw("/transactions/{$id}/invoice", $params),
         );
 
         return TransactionData::from($parser->getData());

--- a/tests/Functional/Resources/NotificationSettings/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/NotificationSettings/_fixtures/response/list_paginated_page_one.json
@@ -1,0 +1,115 @@
+{
+    "data": [
+        {
+            "id": "ntfset_01gkpjp8bkm3tm53kdgkx6sms7",
+            "description": "Slack notifications",
+            "type": "url",
+            "destination": "https://hooks.slack.com/example",
+            "active": true,
+            "api_version": 1,
+            "include_sensitive_fields": false,
+            "subscribed_events": [
+                {
+                    "name": "transaction.billed",
+                    "description": "Occurs when a transaction is billed.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.canceled",
+                    "description": "Occurs when a transaction is canceled.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.completed",
+                    "description": "Occurs when a transaction is completed.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.created",
+                    "description": "Occurs when a transaction is created.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.payment_failed",
+                    "description": "Occurs when a payment fails for a transaction.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.ready",
+                    "description": "Occurs when a transaction is ready.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "transaction.updated",
+                    "description": "Occurs when a transaction is updated.",
+                    "group": "Transaction",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.activated",
+                    "description": "Occurs when a subscription is activated.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.canceled",
+                    "description": "Occurs when a subscription is canceled.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.created",
+                    "description": "Occurs when a subscription is created.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.past_due",
+                    "description": "Occurs when a subscription is past due.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.paused",
+                    "description": "Occurs when a subscription is paused.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.resumed",
+                    "description": "Occurs when a subscription is resumed.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.trialing",
+                    "description": "Occurs when a subscription is trialing.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                },
+                {
+                    "name": "subscription.updated",
+                    "description": "Occurs when a subscription is updated.",
+                    "group": "Subscription",
+                    "available_versions": [1]
+                }
+            ],
+            "endpoint_secret_key": "pdl_ntfset_01gkpjp8bkm3tm53kdgkx6sms7_6h3qd3uFSi9YCD3OLYAShQI90XTI5vEI"
+        }
+    ],
+    "meta": {
+        "request_id": "cf039cbb-6c2a-485d-b244-501894b797a6",
+        "pagination": {
+            "per_page": 1,
+            "next": "https://api.paddle.com/notification-settings?after=ntfset_01gkpjp8bkm3tm53kdgkx6sms7",
+            "has_more": true,
+            "estimated_total": 2
+        }
+    }
+}

--- a/tests/Functional/Resources/NotificationSettings/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/NotificationSettings/_fixtures/response/list_paginated_page_two.json
@@ -1,108 +1,6 @@
 {
     "data": [
         {
-            "id": "ntfset_01gkpjp8bkm3tm53kdgkx6sms7",
-            "description": "Slack notifications",
-            "type": "url",
-            "destination": "https://hooks.slack.com/example",
-            "active": true,
-            "api_version": 1,
-            "include_sensitive_fields": false,
-            "subscribed_events": [
-                {
-                    "name": "transaction.billed",
-                    "description": "Occurs when a transaction is billed.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.canceled",
-                    "description": "Occurs when a transaction is canceled.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.completed",
-                    "description": "Occurs when a transaction is completed.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.created",
-                    "description": "Occurs when a transaction is created.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.payment_failed",
-                    "description": "Occurs when a payment fails for a transaction.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.ready",
-                    "description": "Occurs when a transaction is ready.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "transaction.updated",
-                    "description": "Occurs when a transaction is updated.",
-                    "group": "Transaction",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.activated",
-                    "description": "Occurs when a subscription is activated.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.canceled",
-                    "description": "Occurs when a subscription is canceled.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.created",
-                    "description": "Occurs when a subscription is created.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.past_due",
-                    "description": "Occurs when a subscription is past due.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.paused",
-                    "description": "Occurs when a subscription is paused.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.resumed",
-                    "description": "Occurs when a subscription is resumed.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.trialing",
-                    "description": "Occurs when a subscription is trialing.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                },
-                {
-                    "name": "subscription.updated",
-                    "description": "Occurs when a subscription is updated.",
-                    "group": "Subscription",
-                    "available_versions": [1]
-                }
-            ],
-            "endpoint_secret_key": "pdl_ntfset_01gkpjp8bkm3tm53kdgkx6sms7_6h3qd3uFSi9YCD3OLYAShQI90XTI5vEI"
-        },
-        {
             "id": "ntfset_01gkpop8bkm3tm53itgkx6klk7",
             "description": "Discord notifications",
             "type": "url",
@@ -208,10 +106,10 @@
     "meta": {
         "request_id": "cf039cbb-6c2a-485d-b244-501894b797a6",
         "pagination": {
-            "per_page": 5,
+            "per_page": 1,
             "next": "https://api.paddle.com/notification-settings?after=ntfset_01gkpop8bkm3tm53itgkx6klk7",
             "has_more": false,
-            "estimated_total": 5
+            "estimated_total": 2
         }
     }
 }

--- a/tests/Functional/Resources/PricingPreviews/PricingPreviewsClientTest.php
+++ b/tests/Functional/Resources/PricingPreviews/PricingPreviewsClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Tests\Functional\Resources\PricingPreviews\Operations;
+namespace Paddle\SDK\Tests\Functional\Resources\PricingPreviews;
 
 use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as MockClient;

--- a/tests/Functional/Resources/PricingPreviews/PricingPreviewsClientTest.php
+++ b/tests/Functional/Resources/PricingPreviews/PricingPreviewsClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Tests\Functional\Resources\Prices;
+namespace Paddle\SDK\Tests\Functional\Resources\PricingPreviews\Operations;
 
 use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as MockClient;

--- a/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
+++ b/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
@@ -7,11 +7,22 @@ namespace Paddle\SDK\Tests\Functional\Resources\Subscriptions;
 use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as MockClient;
 use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Interval;
+use Paddle\SDK\Entities\Shared\Money;
+use Paddle\SDK\Entities\Shared\PriceQuantity;
+use Paddle\SDK\Entities\Shared\TaxCategory;
+use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Subscription\SubscriptionEffectiveFrom;
 use Paddle\SDK\Entities\Subscription\SubscriptionItems;
+use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPrice;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPriceWithProduct;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogProduct;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
 use Paddle\SDK\Entities\Subscription\SubscriptionResumeEffectiveFrom;
@@ -105,6 +116,43 @@ class SubscriptionsClientTest extends TestCase
                 items: [
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
+                    new SubscriptionItemsWithPrice(
+                        new SubscriptionNonCatalogPrice(
+                            'some description',
+                            'some name',
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            TaxMode::AccountSetting(),
+                            new Money('1', CurrencyCode::GBP()),
+                            [],
+                            new PriceQuantity(1, 3),
+                            new CustomData(['key' => 'value']),
+                            new TimePeriod(Interval::Day(), 1),
+                            new TimePeriod(Interval::Day(), 2),
+                        ),
+                        2,
+                    ),
+                    new SubscriptionItemsWithPrice(
+                        new SubscriptionNonCatalogPriceWithProduct(
+                            'some description',
+                            'some name',
+                            new SubscriptionNonCatalogProduct(
+                                'some name',
+                                'some description',
+                                CatalogType::Custom(),
+                                TaxCategory::DigitalGoods(),
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            TaxMode::AccountSetting(),
+                            new Money('1', CurrencyCode::GBP()),
+                            [],
+                            new PriceQuantity(1, 3),
+                            new CustomData(['key' => 'value']),
+                            new TimePeriod(Interval::Day(), 1),
+                            new TimePeriod(Interval::Day(), 2),
+                        ),
+                        2,
+                    ),
                 ],
                 customData: new CustomData(['early_access' => true]),
                 prorationBillingMode: SubscriptionProrationBillingMode::FullImmediately(),
@@ -575,6 +623,43 @@ class SubscriptionsClientTest extends TestCase
                 items: [
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
+                    new SubscriptionItemsWithPrice(
+                        new SubscriptionNonCatalogPrice(
+                            'some description',
+                            'some name',
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            TaxMode::AccountSetting(),
+                            new Money('1', CurrencyCode::GBP()),
+                            [],
+                            new PriceQuantity(1, 3),
+                            new CustomData(['key' => 'value']),
+                            new TimePeriod(Interval::Day(), 1),
+                            new TimePeriod(Interval::Day(), 2),
+                        ),
+                        2,
+                    ),
+                    new SubscriptionItemsWithPrice(
+                        new SubscriptionNonCatalogPriceWithProduct(
+                            'some description',
+                            'some name',
+                            new SubscriptionNonCatalogProduct(
+                                'some name',
+                                'some description',
+                                CatalogType::Custom(),
+                                TaxCategory::DigitalGoods(),
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            TaxMode::AccountSetting(),
+                            new Money('1', CurrencyCode::GBP()),
+                            [],
+                            new PriceQuantity(1, 3),
+                            new CustomData(['key' => 'value']),
+                            new TimePeriod(Interval::Day(), 1),
+                            new TimePeriod(Interval::Day(), 2),
+                        ),
+                        2,
+                    ),
                 ],
                 customData: new CustomData(['early_access' => true]),
                 prorationBillingMode: SubscriptionProrationBillingMode::FullImmediately(),

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full.json
@@ -13,7 +13,74 @@
     "scheduled_change": null,
     "items": [
         { "price_id": "pri_01gsz91wy9k1yn7kx82aafwvea", "quantity": 1 },
-        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 }
+        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product": {
+                    "custom_data": {
+                        "key": "value"
+                    },
+                    "description": "some description",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "name": "some name",
+                    "tax_category": "digital-goods",
+                    "type": "custom"
+                },
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        }
     ],
     "proration_billing_mode": "full_immediately",
     "custom_data": {

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full.json
@@ -13,7 +13,74 @@
     "scheduled_change": null,
     "items": [
         { "price_id": "pri_01gsz91wy9k1yn7kx82aafwvea", "quantity": 1 },
-        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 }
+        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product": {
+                    "custom_data": {
+                        "key": "value"
+                    },
+                    "description": "some description",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "name": "some name",
+                    "tax_category": "digital-goods",
+                    "type": "custom"
+                },
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        }
     ],
     "proration_billing_mode": "full_immediately",
     "custom_data": {

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -30,6 +30,7 @@ use Paddle\SDK\Resources\Shared\Operations\List\Comparator;
 use Paddle\SDK\Resources\Shared\Operations\List\DateComparison;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
@@ -531,12 +532,12 @@ class TransactionsClientTest extends TestCase
      */
     public function get_invoice_pdf_hits_expected_uri(
         string $id,
-        Disposition|null $disposition,
+        GetTransactionInvoice $getOperation,
         ResponseInterface $response,
         string $expectedUri,
     ): void {
         $this->mockClient->addResponse($response);
-        $this->client->transactions->getInvoicePDF($id, $disposition);
+        $this->client->transactions->getInvoicePDF($id, $getOperation);
         $request = $this->mockClient->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);
@@ -548,21 +549,21 @@ class TransactionsClientTest extends TestCase
     {
         yield 'Default' => [
             'txn_01hen7bxc1p8ep4yk7n5jbzk9r',
-            null,
+            new GetTransactionInvoice(),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r/invoice', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Disposition Inline' => [
             'txn_02hen7bxc1p8ep4yk7n5jbzk9r',
-            Disposition::Inline(),
+            new GetTransactionInvoice(Disposition::Inline()),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_02hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=inline', Environment::SANDBOX->baseUrl()),
         ];
 
         yield 'Disposition Attachment' => [
             'txn_03hen7bxc1p8ep4yk7n5jbzk9r',
-            Disposition::Attachment(),
+            new GetTransactionInvoice(Disposition::Attachment()),
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_03hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=attachment', Environment::SANDBOX->baseUrl()),
         ];

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -11,6 +11,7 @@ use Paddle\SDK\Entities\Shared\BillingDetails;
 use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Disposition;
 use Paddle\SDK\Entities\Shared\Interval;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
@@ -529,11 +530,13 @@ class TransactionsClientTest extends TestCase
      * @dataProvider getInvoicePDFOperationsProvider
      */
     public function get_invoice_pdf_hits_expected_uri(
+        string $id,
+        Disposition|null $disposition,
         ResponseInterface $response,
         string $expectedUri,
     ): void {
         $this->mockClient->addResponse($response);
-        $this->client->transactions->getInvoicePDF('txn_01hen7bxc1p8ep4yk7n5jbzk9r');
+        $this->client->transactions->getInvoicePDF($id, $disposition);
         $request = $this->mockClient->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);
@@ -544,8 +547,24 @@ class TransactionsClientTest extends TestCase
     public static function getInvoicePDFOperationsProvider(): \Generator
     {
         yield 'Default' => [
+            'txn_01hen7bxc1p8ep4yk7n5jbzk9r',
+            null,
             new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
             sprintf('%s/transactions/txn_01hen7bxc1p8ep4yk7n5jbzk9r/invoice', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'Disposition Inline' => [
+            'txn_02hen7bxc1p8ep4yk7n5jbzk9r',
+            Disposition::Inline(),
+            new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
+            sprintf('%s/transactions/txn_02hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=inline', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'Disposition Attachment' => [
+            'txn_03hen7bxc1p8ep4yk7n5jbzk9r',
+            Disposition::Attachment(),
+            new Response(200, body: self::readRawJsonFixture('response/get_invoice_pdf_default')),
+            sprintf('%s/transactions/txn_03hen7bxc1p8ep4yk7n5jbzk9r/invoice?disposition=attachment', Environment::SANDBOX->baseUrl()),
         ];
     }
 }

--- a/tests/Unit/Resources/PricingPreviews/Operations/PreviewPriceTest.php
+++ b/tests/Unit/Resources/PricingPreviews/Operations/PreviewPriceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Unit\Resources\PricingPreviews\Operations;
+
+use Paddle\SDK\Entities\PricingPreview\PricePreviewItem;
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
+use Paddle\SDK\Resources\PricingPreviews\Operations\PreviewPrice;
+use PHPUnit\Framework\TestCase;
+
+class PreviewPriceTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider invalidItemsDataProvider
+     */
+    public function it_validates_items(array $items, string $expectedExceptionMessage): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage($expectedExceptionMessage);
+
+        new PreviewPrice($items);
+    }
+
+    public static function invalidItemsDataProvider(): \Generator
+    {
+        yield 'Empty' => [
+            [],
+            'items cannot be empty',
+        ];
+
+        yield 'Invalid Types' => [
+            ['some string', new PricePreviewItem('pri_01gsz8z1q1n00f12qt82y31smh', 20), 123],
+            sprintf(
+                'expected items to only contain only type/s %s, some string, 123 given',
+                PricePreviewItem::class,
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
### Added
- Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
  https://github.com/PaddleHQ/paddle-php-sdk/pull/65
- `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
  https://github.com/PaddleHQ/paddle-php-sdk/pull/68
- Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
  https://github.com/PaddleHQ/paddle-php-sdk/pull/69
- Support notification settings `active` filter
  https://github.com/PaddleHQ/paddle-php-sdk/pull/69

### Fixed

- `PreviewPrice` operation no longer allows empty `items`
  https://github.com/PaddleHQ/paddle-php-sdk/pull/67