### PR TITLE
Feature: Support for createdAt and updatedAt on Subscription notification prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - Added `product` to `subscription.items[]`, see [related changelog](https://developer.paddle.com/changelog/2024/subscription-items-product?utm_source=dx&utm_medium=paddle-php-sdk)
 - Added `import_meta` to `transaction`
+- Support for `createdAt` and `updatedAt` on Subscription notification prices
 
 ## [1.1.2] - 2024-08-23
 

--- a/src/Notifications/Entities/Subscription/SubscriptionPrice.php
+++ b/src/Notifications/Entities/Subscription/SubscriptionPrice.php
@@ -42,8 +42,8 @@ class SubscriptionPrice
         public Status|null $status,
         public CustomData|null $customData,
         public ImportMeta|null $importMeta,
-        public \DateTimeInterface|null $createdAt,
-        public \DateTimeInterface|null $updatedAt,
+        public \DateTimeInterface $createdAt,
+        public \DateTimeInterface $updatedAt,
     ) {
     }
 
@@ -67,8 +67,8 @@ class SubscriptionPrice
             status: isset($data['status']) ? Status::from($data['status']) : null,
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
             importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
-            createdAt: isset($data['created_at']) ? DateTime::from($data['created_at']) : null,
-            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            createdAt: DateTime::from($data['created_at']),
+            updatedAt: DateTime::from($data['updated_at']),
         );
     }
 }

--- a/src/Notifications/Entities/Subscription/SubscriptionPrice.php
+++ b/src/Notifications/Entities/Subscription/SubscriptionPrice.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Notifications\Entities\Subscription;
 
+use Paddle\SDK\Notifications\Entities\DateTime;
 use Paddle\SDK\Notifications\Entities\Shared\CatalogType;
 use Paddle\SDK\Notifications\Entities\Shared\CustomData;
 use Paddle\SDK\Notifications\Entities\Shared\ImportMeta;
@@ -41,6 +42,8 @@ class SubscriptionPrice
         public Status|null $status,
         public CustomData|null $customData,
         public ImportMeta|null $importMeta,
+        public \DateTimeInterface|null $createdAt,
+        public \DateTimeInterface|null $updatedAt,
     ) {
     }
 
@@ -64,6 +67,8 @@ class SubscriptionPrice
             status: isset($data['status']) ? Status::from($data['status']) : null,
             customData: isset($data['custom_data']) ? new CustomData($data['custom_data']) : null,
             importMeta: isset($data['import_meta']) ? ImportMeta::from($data['import_meta']) : null,
+            createdAt: isset($data['created_at']) ? DateTime::from($data['created_at']) : null,
+            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
         );
     }
 }

--- a/tests/Functional/Resources/Events/EventsClientTest.php
+++ b/tests/Functional/Resources/Events/EventsClientTest.php
@@ -155,7 +155,7 @@ class EventsClientTest extends TestCase
         $price2 = $subscriptionEvent->data->items[1]->price;
         self::assertNull($price2->status);
         self::assertNull($price2->quantity);
-        self::assertNull($price2->createdAt);
-        self::assertNull($price2->updatedAt);
+        self::assertSame('2023-04-24T14:11:13.014+00:00', $price1->createdAt->format(\DATE_RFC3339_EXTENDED));
+        self::assertSame('2023-11-24T14:12:05.528+00:00', $price1->updatedAt->format(\DATE_RFC3339_EXTENDED));
     }
 }

--- a/tests/Functional/Resources/Events/EventsClientTest.php
+++ b/tests/Functional/Resources/Events/EventsClientTest.php
@@ -10,9 +10,9 @@ use Paddle\SDK\Client;
 use Paddle\SDK\Entities\Shared\Status;
 use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Environment;
-use Paddle\SDK\Notifications\Entities\Price;
 use Paddle\SDK\Notifications\Entities\Product;
 use Paddle\SDK\Notifications\Entities\Shared\Interval;
+use Paddle\SDK\Notifications\Entities\Subscription\SubscriptionPrice;
 use Paddle\SDK\Options;
 use Paddle\SDK\Resources\Events\Operations\ListEvents;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
@@ -128,27 +128,34 @@ class EventsClientTest extends TestCase
 
         $subscriptionEvent = $subscriptionEvents[0];
 
-        /** @var Price $price */
-        $price = $subscriptionEvent->data->items[0]->price;
+        /** @var SubscriptionPrice $price1 */
+        $price1 = $subscriptionEvent->data->items[0]->price;
 
-        self::assertSame('pri_01gsz8x8sawmvhz1pv30nge1ke', $price->id);
-        self::assertSame('pro_01gsz4t5hdjse780zja8vvr7jg', $price->productId);
-        self::assertNull($price->name);
-        self::assertSame('Monthly (per seat)', $price->description);
-        self::assertNull($price->type);
-        self::assertSame(Interval::Month()->getValue(), $price->billingCycle->interval->getValue());
-        self::assertSame(1, $price->billingCycle->frequency);
-        self::assertNull($price->trialPeriod);
-        self::assertSame(TaxMode::AccountSetting()->getValue(), $price->taxMode->getValue());
-        self::assertSame('3600', $price->unitPrice->amount);
-        self::assertNull($price->unitPrice->currencyCode);
-        self::assertSame([], $price->unitPriceOverrides);
-        self::assertSame(1, $price->quantity->minimum);
-        self::assertSame(999, $price->quantity->maximum);
-        self::assertSame(Status::Active()->getValue(), $price->status->getValue());
-        self::assertNull($price->customData);
-        self::assertNull($price->importMeta);
-        self::assertNull($price->createdAt);
-        self::assertNull($price->updatedAt);
+        self::assertSame('pri_01gsz8x8sawmvhz1pv30nge1ke', $price1->id);
+        self::assertSame('pro_01gsz4t5hdjse780zja8vvr7jg', $price1->productId);
+        self::assertNull($price1->name);
+        self::assertSame('Monthly (per seat)', $price1->description);
+        self::assertNull($price1->type);
+        self::assertSame(Interval::Month()->getValue(), $price1->billingCycle->interval->getValue());
+        self::assertSame(1, $price1->billingCycle->frequency);
+        self::assertNull($price1->trialPeriod);
+        self::assertSame(TaxMode::AccountSetting()->getValue(), $price1->taxMode->getValue());
+        self::assertSame('3600', $price1->unitPrice->amount);
+        self::assertNull($price1->unitPrice->currencyCode);
+        self::assertSame([], $price1->unitPriceOverrides);
+        self::assertSame(1, $price1->quantity->minimum);
+        self::assertSame(999, $price1->quantity->maximum);
+        self::assertSame(Status::Active()->getValue(), $price1->status->getValue());
+        self::assertNull($price1->customData);
+        self::assertNull($price1->importMeta);
+        self::assertSame('2023-04-24T14:11:13.014+00:00', $price1->createdAt->format(\DATE_RFC3339_EXTENDED));
+        self::assertSame('2023-11-24T14:12:05.528+00:00', $price1->updatedAt->format(\DATE_RFC3339_EXTENDED));
+
+        /** @var SubscriptionPrice $price2 */
+        $price2 = $subscriptionEvent->data->items[1]->price;
+        self::assertNull($price2->status);
+        self::assertNull($price2->quantity);
+        self::assertNull($price2->createdAt);
+        self::assertNull($price2->updatedAt);
     }
 }

--- a/tests/Functional/Resources/Events/EventsClientTest.php
+++ b/tests/Functional/Resources/Events/EventsClientTest.php
@@ -7,8 +7,12 @@ namespace Paddle\SDK\Tests\Functional\Resources\Events;
 use GuzzleHttp\Psr7\Response;
 use Http\Mock\Client as MockClient;
 use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Shared\Status;
+use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Environment;
+use Paddle\SDK\Notifications\Entities\Price;
 use Paddle\SDK\Notifications\Entities\Product;
+use Paddle\SDK\Notifications\Entities\Shared\Interval;
 use Paddle\SDK\Options;
 use Paddle\SDK\Resources\Events\Operations\ListEvents;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
@@ -101,5 +105,50 @@ class EventsClientTest extends TestCase
         $subscriptionEvent = $subscriptionEvents[0];
         self::assertNull($subscriptionEvent->data->items[0]->product);
         self::assertInstanceOf(Product::class, $subscriptionEvent->data->items[1]->product);
+    }
+
+    /**
+     * @test
+     */
+    public function list_handles_subscription_events_with_price(): void
+    {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/list_default')));
+        $events = $this->client->events->list(new ListEvents());
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+
+        $subscriptionEvents = array_values(
+            array_filter(
+                iterator_to_array($events),
+                fn ($event) => (string) $event->eventType === 'subscription.updated',
+            ),
+        );
+
+        $subscriptionEvent = $subscriptionEvents[0];
+
+        /** @var Price $price */
+        $price = $subscriptionEvent->data->items[0]->price;
+
+        self::assertSame('pri_01gsz8x8sawmvhz1pv30nge1ke', $price->id);
+        self::assertSame('pro_01gsz4t5hdjse780zja8vvr7jg', $price->productId);
+        self::assertNull($price->name);
+        self::assertSame('Monthly (per seat)', $price->description);
+        self::assertNull($price->type);
+        self::assertSame(Interval::Month()->getValue(), $price->billingCycle->interval->getValue());
+        self::assertSame(1, $price->billingCycle->frequency);
+        self::assertNull($price->trialPeriod);
+        self::assertSame(TaxMode::AccountSetting()->getValue(), $price->taxMode->getValue());
+        self::assertSame('3600', $price->unitPrice->amount);
+        self::assertNull($price->unitPrice->currencyCode);
+        self::assertSame([], $price->unitPriceOverrides);
+        self::assertSame(1, $price->quantity->minimum);
+        self::assertSame(999, $price->quantity->maximum);
+        self::assertSame(Status::Active()->getValue(), $price->status->getValue());
+        self::assertNull($price->customData);
+        self::assertNull($price->importMeta);
+        self::assertNull($price->createdAt);
+        self::assertNull($price->updatedAt);
     }
 }

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -45,7 +45,12 @@
                             "billing_cycle": {
                                 "interval": "month",
                                 "frequency": 1
-                            }
+                            },
+                            "quantity": {
+                                "maximum": 999,
+                                "minimum": 1
+                            },
+                            "status": "active"
                         },
                         "status": "active",
                         "quantity": 10,
@@ -1759,7 +1764,12 @@
                             "billing_cycle": {
                                 "interval": "month",
                                 "frequency": 1
-                            }
+                            },
+                            "quantity": {
+                                "maximum": 999,
+                                "minimum": 1
+                            },
+                            "status": "active"
                         },
                         "status": "active",
                         "quantity": 10,
@@ -1784,7 +1794,12 @@
                             "billing_cycle": {
                                 "interval": "month",
                                 "frequency": 1
-                            }
+                            },
+                            "quantity": {
+                                "maximum": 999,
+                                "minimum": 1
+                            },
+                            "status": "active"
                         },
                         "status": "active",
                         "quantity": 1,

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -50,7 +50,9 @@
                                 "maximum": 999,
                                 "minimum": 1
                             },
-                            "status": "active"
+                            "status": "active",
+                            "created_at": "2023-04-24T14:11:13.014124Z",
+                            "updated_at": "2023-11-24T14:12:05.528Z"
                         },
                         "status": "active",
                         "quantity": 10,

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -77,7 +77,9 @@
                             "billing_cycle": {
                                 "interval": "month",
                                 "frequency": 1
-                            }
+                            },
+                            "created_at": "2023-04-24T14:11:13.014124Z",
+                            "updated_at": "2023-11-24T14:12:05.528Z"
                         },
                         "status": "active",
                         "quantity": 1,
@@ -1771,7 +1773,9 @@
                                 "maximum": 999,
                                 "minimum": 1
                             },
-                            "status": "active"
+                            "status": "active",
+                            "created_at": "2023-04-24T14:11:13.014124Z",
+                            "updated_at": "2023-11-24T14:12:05.528Z"
                         },
                         "status": "active",
                         "quantity": 10,
@@ -1801,7 +1805,9 @@
                                 "maximum": 999,
                                 "minimum": 1
                             },
-                            "status": "active"
+                            "status": "active",
+                            "created_at": "2023-04-24T14:11:13.014124Z",
+                            "updated_at": "2023-11-24T14:12:05.528Z"
                         },
                         "status": "active",
                         "quantity": 1,

--- a/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
@@ -367,7 +367,9 @@
                                     "maximum": 999,
                                     "minimum": 1
                                 },
-                                "status": "active"
+                                "status": "active",
+                                "created_at": "2023-04-24T14:11:13.014124Z",
+                                "updated_at": "2023-11-24T14:12:05.528Z"
                             },
                             "status": "trialing",
                             "quantity": 1,

--- a/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
@@ -362,7 +362,12 @@
                                 "billing_cycle": {
                                     "interval": "year",
                                     "frequency": 1
-                                }
+                                },
+                                "quantity": {
+                                    "maximum": 999,
+                                    "minimum": 1
+                                },
+                                "status": "active"
                             },
                             "status": "trialing",
                             "quantity": 1,


### PR DESCRIPTION
### Added
- Support for `createdAt` and `updatedAt` on Subscription notification prices