### PR TITLE
feat: Webhook Notification Types

### DIFF
--- a/examples/webhook_verification_PSR7.php
+++ b/examples/webhook_verification_PSR7.php
@@ -11,6 +11,8 @@ require 'vendor/autoload.php';
  */
 
 use GuzzleHttp\Psr7\ServerRequest;
+use Paddle\SDK\Notifications\Events\TransactionUpdated;
+use Paddle\SDK\Notifications\Notification;
 use Paddle\SDK\Notifications\Secret;
 use Paddle\SDK\Notifications\Verifier;
 
@@ -21,6 +23,18 @@ $isVerified = (new Verifier())->verify($request, new Secret('WEBHOOK_SECRET_KEY'
 
 if ($isVerified) {
     echo "Webhook is verified\n";
+
+    $data = json_decode((string) $request->getBody(), true, JSON_THROW_ON_ERROR);
+    $notification = Notification::from($data);
+    $id = $notification->id;
+    $event = $notification->event;
+    $eventId = $event->eventId;
+    $eventType = $event->eventType;
+    $occurredAt = $event->occurredAt;
+
+    if ($event instanceof TransactionUpdated) {
+        $transactionId = $event->transaction->id;
+    }
 } else {
     echo "Webhook is not verified\n";
 }

--- a/examples/webhook_verification_PSR7.php
+++ b/examples/webhook_verification_PSR7.php
@@ -11,8 +11,8 @@ require 'vendor/autoload.php';
  */
 
 use GuzzleHttp\Psr7\ServerRequest;
-use Paddle\SDK\Notifications\Events\TransactionUpdated;
 use Paddle\SDK\Notifications\Notification;
+use Paddle\SDK\Notifications\Notification\TransactionUpdatedNotification;
 use Paddle\SDK\Notifications\Secret;
 use Paddle\SDK\Notifications\Verifier;
 
@@ -26,13 +26,12 @@ if ($isVerified) {
 
     $notification = Notification::fromRequest($request);
     $id = $notification->id;
-    $event = $notification->event;
-    $eventId = $event->eventId;
-    $eventType = $event->eventType;
-    $occurredAt = $event->occurredAt;
+    $eventId = $notification->eventId;
+    $eventType = $notification->eventType;
+    $occurredAt = $notification->occurredAt;
 
-    if ($event instanceof TransactionUpdated) {
-        $transactionId = $event->transaction->id;
+    if ($notification instanceof TransactionUpdatedNotification) {
+        $transactionId = $notification->transaction->id;
     }
 } else {
     echo "Webhook is not verified\n";

--- a/examples/webhook_verification_PSR7.php
+++ b/examples/webhook_verification_PSR7.php
@@ -24,8 +24,7 @@ $isVerified = (new Verifier())->verify($request, new Secret('WEBHOOK_SECRET_KEY'
 if ($isVerified) {
     echo "Webhook is verified\n";
 
-    $data = json_decode((string) $request->getBody(), true, JSON_THROW_ON_ERROR);
-    $notification = Notification::from($data);
+    $notification = Notification::fromRequest($request);
     $id = $notification->id;
     $event = $notification->event;
     $eventId = $event->eventId;

--- a/src/Entities/Event.php
+++ b/src/Entities/Event.php
@@ -9,14 +9,11 @@ use Paddle\SDK\Notifications\Entities\Entity as NotificationEntity;
 
 abstract class Event implements Entity
 {
-    /**
-     * @internal
-     */
     protected function __construct(
-        public string $eventId,
-        public EventTypeName $eventType,
-        public \DateTimeInterface $occurredAt,
-        public NotificationEntity $data,
+        public readonly string $eventId,
+        public readonly EventTypeName $eventType,
+        public readonly \DateTimeInterface $occurredAt,
+        public readonly NotificationEntity $data,
     ) {
     }
 

--- a/src/Notifications/Events/AddressCreated.php
+++ b/src/Notifications/Events/AddressCreated.php
@@ -15,9 +15,9 @@ final class AddressCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Address $data,
+        public readonly Address $address,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $address);
     }
 
     /**

--- a/src/Notifications/Events/AddressUpdated.php
+++ b/src/Notifications/Events/AddressUpdated.php
@@ -15,9 +15,9 @@ final class AddressUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Address $data,
+        public readonly Address $address,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $address);
     }
 
     /**

--- a/src/Notifications/Events/AdjustmentCreated.php
+++ b/src/Notifications/Events/AdjustmentCreated.php
@@ -15,9 +15,9 @@ final class AdjustmentCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Adjustment $data,
+        public readonly Adjustment $adjustment,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $adjustment);
     }
 
     /**

--- a/src/Notifications/Events/AdjustmentUpdated.php
+++ b/src/Notifications/Events/AdjustmentUpdated.php
@@ -15,9 +15,9 @@ final class AdjustmentUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Adjustment $data,
+        public readonly Adjustment $adjustment,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $adjustment);
     }
 
     /**

--- a/src/Notifications/Events/BusinessCreated.php
+++ b/src/Notifications/Events/BusinessCreated.php
@@ -15,9 +15,9 @@ final class BusinessCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Business $data,
+        public readonly Business $business,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $business);
     }
 
     /**

--- a/src/Notifications/Events/BusinessUpdated.php
+++ b/src/Notifications/Events/BusinessUpdated.php
@@ -15,9 +15,9 @@ final class BusinessUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Business $data,
+        public readonly Business $business,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $business);
     }
 
     /**

--- a/src/Notifications/Events/CustomerCreated.php
+++ b/src/Notifications/Events/CustomerCreated.php
@@ -15,9 +15,9 @@ final class CustomerCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Customer $data,
+        public readonly Customer $customer,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $customer);
     }
 
     /**

--- a/src/Notifications/Events/CustomerUpdated.php
+++ b/src/Notifications/Events/CustomerUpdated.php
@@ -15,9 +15,9 @@ final class CustomerUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Customer $data,
+        public readonly Customer $customer,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $customer);
     }
 
     /**

--- a/src/Notifications/Events/DiscountCreated.php
+++ b/src/Notifications/Events/DiscountCreated.php
@@ -15,9 +15,9 @@ final class DiscountCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Discount $data,
+        public readonly Discount $discount,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $discount);
     }
 
     /**

--- a/src/Notifications/Events/DiscountImported.php
+++ b/src/Notifications/Events/DiscountImported.php
@@ -15,9 +15,9 @@ final class DiscountImported extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Discount $data,
+        public readonly Discount $discount,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $discount);
     }
 
     /**

--- a/src/Notifications/Events/DiscountUpdated.php
+++ b/src/Notifications/Events/DiscountUpdated.php
@@ -15,9 +15,9 @@ final class DiscountUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Discount $data,
+        public readonly Discount $discount,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $discount);
     }
 
     /**

--- a/src/Notifications/Events/PayoutCreated.php
+++ b/src/Notifications/Events/PayoutCreated.php
@@ -15,9 +15,9 @@ final class PayoutCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Payout $data,
+        public readonly Payout $payout,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $payout);
     }
 
     /**

--- a/src/Notifications/Events/PayoutPaid.php
+++ b/src/Notifications/Events/PayoutPaid.php
@@ -15,9 +15,9 @@ final class PayoutPaid extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Payout $data,
+        public readonly Payout $payout,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $payout);
     }
 
     /**

--- a/src/Notifications/Events/PriceCreated.php
+++ b/src/Notifications/Events/PriceCreated.php
@@ -15,9 +15,9 @@ final class PriceCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Price $data,
+        public readonly Price $price,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $price);
     }
 
     /**

--- a/src/Notifications/Events/PriceUpdated.php
+++ b/src/Notifications/Events/PriceUpdated.php
@@ -15,9 +15,9 @@ final class PriceUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Price $data,
+        public readonly Price $price,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $price);
     }
 
     /**

--- a/src/Notifications/Events/ProductCreated.php
+++ b/src/Notifications/Events/ProductCreated.php
@@ -15,9 +15,9 @@ final class ProductCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Product $data,
+        public readonly Product $product,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $product);
     }
 
     /**

--- a/src/Notifications/Events/ProductUpdated.php
+++ b/src/Notifications/Events/ProductUpdated.php
@@ -15,9 +15,9 @@ final class ProductUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Product $data,
+        public readonly Product $product,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $product);
     }
 
     /**

--- a/src/Notifications/Events/ReportCreated.php
+++ b/src/Notifications/Events/ReportCreated.php
@@ -15,9 +15,9 @@ final class ReportCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Report $data,
+        public readonly Report $report,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $report);
     }
 
     /**

--- a/src/Notifications/Events/ReportUpdated.php
+++ b/src/Notifications/Events/ReportUpdated.php
@@ -15,9 +15,9 @@ final class ReportUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Report $data,
+        public readonly Report $report,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $report);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionActivated.php
+++ b/src/Notifications/Events/SubscriptionActivated.php
@@ -15,9 +15,9 @@ final class SubscriptionActivated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionCanceled.php
+++ b/src/Notifications/Events/SubscriptionCanceled.php
@@ -15,9 +15,9 @@ final class SubscriptionCanceled extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionCreated.php
+++ b/src/Notifications/Events/SubscriptionCreated.php
@@ -15,9 +15,9 @@ final class SubscriptionCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionImported.php
+++ b/src/Notifications/Events/SubscriptionImported.php
@@ -15,9 +15,9 @@ final class SubscriptionImported extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionPastDue.php
+++ b/src/Notifications/Events/SubscriptionPastDue.php
@@ -15,9 +15,9 @@ final class SubscriptionPastDue extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionPaused.php
+++ b/src/Notifications/Events/SubscriptionPaused.php
@@ -15,9 +15,9 @@ final class SubscriptionPaused extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionResumed.php
+++ b/src/Notifications/Events/SubscriptionResumed.php
@@ -15,9 +15,9 @@ final class SubscriptionResumed extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionTrialing.php
+++ b/src/Notifications/Events/SubscriptionTrialing.php
@@ -15,9 +15,9 @@ final class SubscriptionTrialing extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/SubscriptionUpdated.php
+++ b/src/Notifications/Events/SubscriptionUpdated.php
@@ -15,9 +15,9 @@ final class SubscriptionUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Subscription $data,
+        public readonly Subscription $subscription,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $subscription);
     }
 
     /**

--- a/src/Notifications/Events/TransactionBilled.php
+++ b/src/Notifications/Events/TransactionBilled.php
@@ -15,9 +15,9 @@ final class TransactionBilled extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionCanceled.php
+++ b/src/Notifications/Events/TransactionCanceled.php
@@ -15,9 +15,9 @@ final class TransactionCanceled extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionCompleted.php
+++ b/src/Notifications/Events/TransactionCompleted.php
@@ -15,9 +15,9 @@ final class TransactionCompleted extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionCreated.php
+++ b/src/Notifications/Events/TransactionCreated.php
@@ -15,9 +15,9 @@ final class TransactionCreated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionPaid.php
+++ b/src/Notifications/Events/TransactionPaid.php
@@ -15,9 +15,9 @@ final class TransactionPaid extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionPastDue.php
+++ b/src/Notifications/Events/TransactionPastDue.php
@@ -15,9 +15,9 @@ final class TransactionPastDue extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionPaymentFailed.php
+++ b/src/Notifications/Events/TransactionPaymentFailed.php
@@ -15,9 +15,9 @@ final class TransactionPaymentFailed extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionReady.php
+++ b/src/Notifications/Events/TransactionReady.php
@@ -15,9 +15,9 @@ final class TransactionReady extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Events/TransactionUpdated.php
+++ b/src/Notifications/Events/TransactionUpdated.php
@@ -15,9 +15,9 @@ final class TransactionUpdated extends Event
         string $eventId,
         EventTypeName $eventType,
         \DateTimeInterface $occurredAt,
-        Transaction $data,
+        public readonly Transaction $transaction,
     ) {
-        parent::__construct($eventId, $eventType, $occurredAt, $data);
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction);
     }
 
     /**

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -6,6 +6,7 @@ namespace Paddle\SDK\Notifications;
 
 use Paddle\SDK\Entities\Event;
 use Paddle\SDK\Notifications\Entities\Entity;
+use Psr\Http\Message\ServerRequestInterface;
 
 class Notification implements Entity
 {
@@ -21,5 +22,14 @@ class Notification implements Entity
             $data['notification_id'],
             Event::from($data),
         );
+    }
+
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        return self::from(json_decode(
+            (string) $request->getBody(),
+            true,
+            JSON_THROW_ON_ERROR,
+        ));
     }
 }

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Entity;
+
+class Notification implements Entity
+{
+    private function __construct(
+        public readonly string $id,
+        public readonly Event $event,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            $data['notification_id'],
+            Event::from($data),
+        );
+    }
+}

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -5,23 +5,23 @@ declare(strict_types=1);
 namespace Paddle\SDK\Notifications;
 
 use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Entities\Event\EventTypeName;
 use Paddle\SDK\Notifications\Entities\Entity;
 use Psr\Http\Message\ServerRequestInterface;
 
-class Notification implements Entity
+abstract class Notification implements Entity
 {
-    private function __construct(
-        public readonly string $id,
-        public readonly Event $event,
-    ) {
-    }
+    public readonly string $eventId;
+    public readonly EventTypeName $eventType;
+    public readonly \DateTimeInterface $occurredAt;
 
-    public static function from(array $data): self
-    {
-        return new self(
-            $data['notification_id'],
-            Event::from($data),
-        );
+    protected function __construct(
+        public readonly string $id,
+        Event $event,
+    ) {
+        $this->eventId = $event->eventId;
+        $this->eventType = $event->eventType;
+        $this->occurredAt = $event->occurredAt;
     }
 
     public static function fromRequest(ServerRequestInterface $request): self
@@ -32,4 +32,27 @@ class Notification implements Entity
             JSON_THROW_ON_ERROR,
         ));
     }
+
+    public static function from(array $data): self
+    {
+        $type = explode('.', (string) $data['event_type']);
+        $identifier = str_replace('_', '', ucwords(implode('_', $type), '_'));
+
+        /** @var class-string<Notification> $notification */
+        $notification = sprintf('\Paddle\SDK\Notifications\Notification\%sNotification', $identifier);
+
+        if (! class_exists($notification) || ! is_subclass_of($notification, self::class)) {
+            throw new \UnexpectedValueException("Notification type '{$identifier}' cannot be mapped to an object");
+        }
+
+        return $notification::fromEvent(
+            $data['notification_id'],
+            Event::from($data),
+        );
+    }
+
+    abstract protected static function fromEvent(
+        string $id,
+        Event $event,
+    ): static;
 }

--- a/src/Notifications/Notification/AddressCreatedNotification.php
+++ b/src/Notifications/Notification/AddressCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Address;
+use Paddle\SDK\Notifications\Events\AddressCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class AddressCreatedNotification extends Notification
+{
+    public readonly Address $address;
+
+    private function __construct(string $id, AddressCreated $event)
+    {
+        $this->address = $event->address;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param AddressCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/AddressUpdatedNotification.php
+++ b/src/Notifications/Notification/AddressUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Address;
+use Paddle\SDK\Notifications\Events\AddressUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class AddressUpdatedNotification extends Notification
+{
+    public readonly Address $address;
+
+    private function __construct(string $id, AddressUpdated $event)
+    {
+        $this->address = $event->address;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param AddressUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/AdjustmentCreatedNotification.php
+++ b/src/Notifications/Notification/AdjustmentCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Adjustment;
+use Paddle\SDK\Notifications\Events\AdjustmentCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class AdjustmentCreatedNotification extends Notification
+{
+    public readonly Adjustment $adjustment;
+
+    private function __construct(string $id, AdjustmentCreated $event)
+    {
+        $this->adjustment = $event->adjustment;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param AdjustmentCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/AdjustmentUpdatedNotification.php
+++ b/src/Notifications/Notification/AdjustmentUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Adjustment;
+use Paddle\SDK\Notifications\Events\AdjustmentUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class AdjustmentUpdatedNotification extends Notification
+{
+    public readonly Adjustment $adjustment;
+
+    private function __construct(string $id, AdjustmentUpdated $event)
+    {
+        $this->adjustment = $event->adjustment;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param AdjustmentUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/BusinessCreatedNotification.php
+++ b/src/Notifications/Notification/BusinessCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Business;
+use Paddle\SDK\Notifications\Events\BusinessCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class BusinessCreatedNotification extends Notification
+{
+    public readonly Business $business;
+
+    private function __construct(string $id, BusinessCreated $event)
+    {
+        $this->business = $event->business;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param BusinessCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/BusinessUpdatedNotification.php
+++ b/src/Notifications/Notification/BusinessUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Business;
+use Paddle\SDK\Notifications\Events\BusinessUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class BusinessUpdatedNotification extends Notification
+{
+    public readonly Business $business;
+
+    private function __construct(string $id, BusinessUpdated $event)
+    {
+        $this->business = $event->business;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param BusinessUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/CustomerCreatedNotification.php
+++ b/src/Notifications/Notification/CustomerCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Customer;
+use Paddle\SDK\Notifications\Events\CustomerCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class CustomerCreatedNotification extends Notification
+{
+    public readonly Customer $customer;
+
+    private function __construct(string $id, CustomerCreated $event)
+    {
+        $this->customer = $event->customer;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param CustomerCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/CustomerUpdatedNotification.php
+++ b/src/Notifications/Notification/CustomerUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Customer;
+use Paddle\SDK\Notifications\Events\CustomerUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class CustomerUpdatedNotification extends Notification
+{
+    public readonly Customer $customer;
+
+    private function __construct(string $id, CustomerUpdated $event)
+    {
+        $this->customer = $event->customer;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param CustomerUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/DiscountCreatedNotification.php
+++ b/src/Notifications/Notification/DiscountCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Discount;
+use Paddle\SDK\Notifications\Events\DiscountCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class DiscountCreatedNotification extends Notification
+{
+    public readonly Discount $discount;
+
+    private function __construct(string $id, DiscountCreated $event)
+    {
+        $this->discount = $event->discount;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param DiscountCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/DiscountImportedNotification.php
+++ b/src/Notifications/Notification/DiscountImportedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Discount;
+use Paddle\SDK\Notifications\Events\DiscountImported;
+use Paddle\SDK\Notifications\Notification;
+
+final class DiscountImportedNotification extends Notification
+{
+    public readonly Discount $discount;
+
+    private function __construct(string $id, DiscountImported $event)
+    {
+        $this->discount = $event->discount;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param DiscountImported $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/DiscountUpdatedNotification.php
+++ b/src/Notifications/Notification/DiscountUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Discount;
+use Paddle\SDK\Notifications\Events\DiscountUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class DiscountUpdatedNotification extends Notification
+{
+    public readonly Discount $discount;
+
+    private function __construct(string $id, DiscountUpdated $event)
+    {
+        $this->discount = $event->discount;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param DiscountUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/PayoutCreatedNotification.php
+++ b/src/Notifications/Notification/PayoutCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Payout;
+use Paddle\SDK\Notifications\Events\PayoutCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class PayoutCreatedNotification extends Notification
+{
+    public readonly Payout $payout;
+
+    private function __construct(string $id, PayoutCreated $event)
+    {
+        $this->payout = $event->payout;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param PayoutCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/PayoutPaidNotification.php
+++ b/src/Notifications/Notification/PayoutPaidNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Payout;
+use Paddle\SDK\Notifications\Events\PayoutPaid;
+use Paddle\SDK\Notifications\Notification;
+
+final class PayoutPaidNotification extends Notification
+{
+    public readonly Payout $payout;
+
+    private function __construct(string $id, PayoutPaid $event)
+    {
+        $this->payout = $event->payout;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param PayoutPaid $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/PriceCreatedNotification.php
+++ b/src/Notifications/Notification/PriceCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Price;
+use Paddle\SDK\Notifications\Events\PriceCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class PriceCreatedNotification extends Notification
+{
+    public readonly Price $price;
+
+    private function __construct(string $id, PriceCreated $event)
+    {
+        $this->price = $event->price;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param PriceCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/PriceUpdatedNotification.php
+++ b/src/Notifications/Notification/PriceUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Price;
+use Paddle\SDK\Notifications\Events\PriceUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class PriceUpdatedNotification extends Notification
+{
+    public readonly Price $price;
+
+    private function __construct(string $id, PriceUpdated $event)
+    {
+        $this->price = $event->price;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param PriceUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/ProductCreatedNotification.php
+++ b/src/Notifications/Notification/ProductCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Product;
+use Paddle\SDK\Notifications\Events\ProductCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class ProductCreatedNotification extends Notification
+{
+    public readonly Product $product;
+
+    private function __construct(string $id, ProductCreated $event)
+    {
+        $this->product = $event->product;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param ProductCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/ProductUpdatedNotification.php
+++ b/src/Notifications/Notification/ProductUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Product;
+use Paddle\SDK\Notifications\Events\ProductUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class ProductUpdatedNotification extends Notification
+{
+    public readonly Product $product;
+
+    private function __construct(string $id, ProductUpdated $event)
+    {
+        $this->product = $event->product;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param ProductUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/ReportCreatedNotification.php
+++ b/src/Notifications/Notification/ReportCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Report;
+use Paddle\SDK\Notifications\Events\ReportCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class ReportCreatedNotification extends Notification
+{
+    public readonly Report $report;
+
+    private function __construct(string $id, ReportCreated $event)
+    {
+        $this->report = $event->report;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param ReportCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/ReportUpdatedNotification.php
+++ b/src/Notifications/Notification/ReportUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Report;
+use Paddle\SDK\Notifications\Events\ReportUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class ReportUpdatedNotification extends Notification
+{
+    public readonly Report $report;
+
+    private function __construct(string $id, ReportUpdated $event)
+    {
+        $this->report = $event->report;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param ReportUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionActivatedNotification.php
+++ b/src/Notifications/Notification/SubscriptionActivatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionActivated;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionActivatedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionActivated $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionActivated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionCanceledNotification.php
+++ b/src/Notifications/Notification/SubscriptionCanceledNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionCanceled;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionCanceledNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionCanceled $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionCanceled $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionCreatedNotification.php
+++ b/src/Notifications/Notification/SubscriptionCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionCreatedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionCreated $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionImportedNotification.php
+++ b/src/Notifications/Notification/SubscriptionImportedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionImported;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionImportedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionImported $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionImported $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionPastDueNotification.php
+++ b/src/Notifications/Notification/SubscriptionPastDueNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionPastDue;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionPastDueNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionPastDue $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionPastDue $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionPausedNotification.php
+++ b/src/Notifications/Notification/SubscriptionPausedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionPaused;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionPausedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionPaused $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionPaused $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionResumedNotification.php
+++ b/src/Notifications/Notification/SubscriptionResumedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionResumed;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionResumedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionResumed $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionResumed $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionTrialingNotification.php
+++ b/src/Notifications/Notification/SubscriptionTrialingNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionTrialing;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionTrialingNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionTrialing $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionTrialing $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/SubscriptionUpdatedNotification.php
+++ b/src/Notifications/Notification/SubscriptionUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Subscription;
+use Paddle\SDK\Notifications\Events\SubscriptionUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class SubscriptionUpdatedNotification extends Notification
+{
+    public readonly Subscription $subscription;
+
+    private function __construct(string $id, SubscriptionUpdated $event)
+    {
+        $this->subscription = $event->subscription;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param SubscriptionUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionBilledNotification.php
+++ b/src/Notifications/Notification/TransactionBilledNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionBilled;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionBilledNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionBilled $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionBilled $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionCanceledNotification.php
+++ b/src/Notifications/Notification/TransactionCanceledNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionCanceled;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionCanceledNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionCanceled $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionCanceled $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionCompletedNotification.php
+++ b/src/Notifications/Notification/TransactionCompletedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionCompleted;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionCompletedNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionCompleted $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionCompleted $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionCreatedNotification.php
+++ b/src/Notifications/Notification/TransactionCreatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionCreated;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionCreatedNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionCreated $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionCreated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionPaidNotification.php
+++ b/src/Notifications/Notification/TransactionPaidNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionPaid;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionPaidNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionPaid $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionPaid $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionPastDueNotification.php
+++ b/src/Notifications/Notification/TransactionPastDueNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionPastDue;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionPastDueNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionPastDue $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionPastDue $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionPaymentFailedNotification.php
+++ b/src/Notifications/Notification/TransactionPaymentFailedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionPaymentFailed;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionPaymentFailedNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionPaymentFailed $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionPaymentFailed $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionReadyNotification.php
+++ b/src/Notifications/Notification/TransactionReadyNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionReady;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionReadyNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionReady $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionReady $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/src/Notifications/Notification/TransactionUpdatedNotification.php
+++ b/src/Notifications/Notification/TransactionUpdatedNotification.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Notification;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Notifications\Entities\Transaction;
+use Paddle\SDK\Notifications\Events\TransactionUpdated;
+use Paddle\SDK\Notifications\Notification;
+
+final class TransactionUpdatedNotification extends Notification
+{
+    public readonly Transaction $transaction;
+
+    private function __construct(string $id, TransactionUpdated $event)
+    {
+        $this->transaction = $event->transaction;
+
+        parent::__construct($id, $event);
+    }
+
+    /**
+     * @param TransactionUpdated $event
+     */
+    protected static function fromEvent(string $id, Event $event): static
+    {
+        return new self($id, $event);
+    }
+}

--- a/tests/Unit/Notifications/NotificationTest.php
+++ b/tests/Unit/Notifications/NotificationTest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Paddle\SDK\Tests\Unit\Notifications;
 
 use Paddle\SDK\Notifications\Entities\Business;
-use Paddle\SDK\Notifications\Entities\Entity;
-use Paddle\SDK\Notifications\Events\BusinessUpdated;
 use Paddle\SDK\Notifications\Notification;
+use Paddle\SDK\Notifications\Notification\BusinessUpdatedNotification;
 use Paddle\SDK\Tests\Utils\ReadsFixtures;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,14 +25,13 @@ class NotificationTest extends TestCase
 
         self::assertSame('ntf_01h8bzam1z32agrxjwhjgqk8w6', $notification->id);
 
-        $event = $notification->event;
-        self::assertInstanceOf(BusinessUpdated::class, $event);
-        self::assertInstanceOf(Entity::class, $event->data);
-        self::assertSame('evt_01h8bzakzx3hm2fmen703n5q45', $event->eventId);
-        self::assertSame('2023-08-21T11:57:47.390+00:00', $event->occurredAt->format(DATE_RFC3339_EXTENDED));
-        self::assertSame('business.updated', $event->eventType->getValue());
+        self::assertInstanceOf(BusinessUpdatedNotification::class, $notification);
 
-        $business = $event->business;
+        self::assertSame('evt_01h8bzakzx3hm2fmen703n5q45', $notification->eventId);
+        self::assertSame('2023-08-21T11:57:47.390+00:00', $notification->occurredAt->format(DATE_RFC3339_EXTENDED));
+        self::assertSame('business.updated', $notification->eventType->getValue());
+
+        $business = $notification->business;
         self::assertInstanceOf(Business::class, $business);
         self::assertSame('biz_01h84a7hr4pzhsajkm8tev89ev', $business->id);
         self::assertSame('ChatApp Inc.', $business->name);

--- a/tests/Unit/Notifications/NotificationTest.php
+++ b/tests/Unit/Notifications/NotificationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Unit\Notifications;
+
+use Paddle\SDK\Notifications\Entities\Business;
+use Paddle\SDK\Notifications\Entities\Entity;
+use Paddle\SDK\Notifications\Events\BusinessUpdated;
+use Paddle\SDK\Notifications\Notification;
+use Paddle\SDK\Tests\Utils\ReadsFixtures;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class NotificationTest extends TestCase
+{
+    use ReadsFixtures;
+
+    /** @test */
+    public function it_creates_from_data(): void
+    {
+        $data = self::readJsonFixture('notification_business_updated');
+
+        $notification = Notification::from($data);
+
+        self::assertSame('ntf_01h8bzam1z32agrxjwhjgqk8w6', $notification->id);
+
+        $event = $notification->event;
+        self::assertInstanceOf(BusinessUpdated::class, $event);
+        self::assertInstanceOf(Entity::class, $event->data);
+        self::assertSame('evt_01h8bzakzx3hm2fmen703n5q45', $event->eventId);
+        self::assertSame('2023-08-21T11:57:47.390+00:00', $event->occurredAt->format(DATE_RFC3339_EXTENDED));
+        self::assertSame('business.updated', $event->eventType->getValue());
+
+        $business = $event->business;
+        self::assertInstanceOf(Business::class, $business);
+        self::assertSame('biz_01h84a7hr4pzhsajkm8tev89ev', $business->id);
+        self::assertSame('ChatApp Inc.', $business->name);
+        self::assertSame('active', $business->status->getValue());
+    }
+
+    /** @test */
+    public function it_creates_from_request(): void
+    {
+        $requestStream = $this->createMock(StreamInterface::class);
+        $requestStream
+            ->method('__toString')
+            ->willReturn(self::readRawJsonFixture('notification_business_updated'));
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->method('getBody')
+            ->willReturn($requestStream);
+
+        $notification = Notification::fromRequest($request);
+
+        self::assertSame('ntf_01h8bzam1z32agrxjwhjgqk8w6', $notification->id);
+    }
+}

--- a/tests/Unit/Notifications/_fixtures/notification_business_updated.json
+++ b/tests/Unit/Notifications/_fixtures/notification_business_updated.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "id": "biz_01h84a7hr4pzhsajkm8tev89ev",
+    "name": "ChatApp Inc.",
+    "status": "active",
+    "contacts": [
+      {
+        "name": "Parker Jones",
+        "email": "parker@example.com"
+      },
+      {
+        "name": "Jo Riley",
+        "email": "jo@example.com"
+      },
+      {
+        "name": "Jesse Garcia",
+        "email": "jo@example.com"
+      }
+    ],
+    "created_at": "2023-08-18T12:34:25.668Z",
+    "updated_at": "2023-08-21T11:57:47.03542Z",
+    "company_number": "555775291485",
+    "tax_identifier": null
+  },
+  "event_id": "evt_01h8bzakzx3hm2fmen703n5q45",
+  "event_type": "business.updated",
+  "occurred_at": "2023-08-21T11:57:47.390028Z",
+  "notification_id": "ntf_01h8bzam1z32agrxjwhjgqk8w6"
+}


### PR DESCRIPTION
### Added
`Paddle\SDK\Notifications\Notification` and subtypes, e.g. `Paddle\SDK\Notifications\Events\TransactionUpdated`

#### Usage
```php
use Paddle\SDK\Notifications\Notification;
use Paddle\SDK\Notifications\Notification\TransactionUpdatedNotification;

$notification = Notification::fromRequest($request);
$id = $notification->id;
$eventId = $notification->eventId;
$eventType = $notification->eventType;
$occurredAt = $notification->occurredAt;

if ($notification instanceof TransactionUpdatedNotification) {
    $transactionId = $notification->transaction->id;
}
```