### PR TITLE
`payment_method_id` can be `string` or `null`

### DIFF
--- a/src/Entities/Shared/TransactionPaymentAttempt.php
+++ b/src/Entities/Shared/TransactionPaymentAttempt.php
@@ -20,7 +20,7 @@ class TransactionPaymentAttempt
      */
     private function __construct(
         public string $paymentAttemptId,
-        public string $paymentMethodId,
+        public string|null $paymentMethodId,
         public string $storedPaymentMethodId,
         public string $amount,
         public PaymentAttemptStatus $status,


### PR DESCRIPTION
The API docs state that the `payment_method_id` can be a `string` or `null` - but the PHP code only expects a string.

The value is `null` when e.g. the payment amount has been reduced to zero by a discount.