### PR TITLE
fix: Add test coverage and CHANGELOG for nullable `payment_method_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - `PreviewPrice` operation no longer allows empty `items`
+- Transaction `payment_method_id` can be `string` or `null`
 
 ## [1.1.2] - 2024-08-23
 

--- a/src/Entities/Shared/TransactionPaymentAttempt.php
+++ b/src/Entities/Shared/TransactionPaymentAttempt.php
@@ -35,7 +35,7 @@ class TransactionPaymentAttempt
     {
         return new self(
             $data['payment_attempt_id'],
-            $data['payment_method_id'],
+            $data['payment_method_id'] ?? null,
             $data['stored_payment_method_id'],
             $data['amount'],
             PaymentAttemptStatus::from($data['status']),

--- a/tests/Functional/Resources/Events/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Events/_fixtures/response/list_default.json
@@ -757,7 +757,7 @@
                             "type": "card"
                         },
                         "payment_attempt_id": "afa07161-601d-4a65-8c1a-6993ae1ae027",
-                        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
+                        "payment_method_id": null,
                         "stored_payment_method_id": "d3218a38-1cff-44a7-8a47-6a809a5ae9ad"
                     }
                 ],

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -420,6 +420,21 @@ class TransactionsClientTest extends TestCase
 
     /**
      * @test
+     */
+    public function get_has_payments_with_and_without_payment_method_id(): void
+    {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/full_entity')));
+        $transaction = $this->client->transactions->get('txn_01hen7bxc1p8ep4yk7n5jbzk9r');
+
+        $paymentWithPaymentMethodId = $transaction->payments[0];
+        self::assertSame('paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1', $paymentWithPaymentMethodId->paymentMethodId);
+
+        $paymentWithoutPaymentMethodId = $transaction->payments[1];
+        self::assertNull($paymentWithoutPaymentMethodId->paymentMethodId);
+    }
+
+    /**
+     * @test
      *
      * @dataProvider previewOperationsProvider
      */

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -159,7 +159,48 @@
         }
       ]
     },
-    "payments": [],
+    "payments": [
+      {
+        "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+        "payment_method_id": "paymtd_01hkm9xwqpbbpr1ksmvg3sx3v1",
+        "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+        "amount": "40000",
+        "status": "captured",
+        "error_code": null,
+        "method_details": {
+          "type": "card",
+          "card": {
+            "type": "visa",
+            "last4": "4242",
+            "expiry_month": 1,
+            "expiry_year": 2024,
+            "cardholder_name": "Joe Bloggs"
+          }
+        },
+        "created_at": "2023-08-18T21:13:07.18821Z",
+        "captured_at": "2023-08-18T21:13:09.477933Z"
+      },
+      {
+        "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+        "payment_method_id": null,
+        "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+        "amount": "40000",
+        "status": "captured",
+        "error_code": null,
+        "method_details": {
+          "type": "card",
+          "card": {
+            "type": "visa",
+            "last4": "4242",
+            "expiry_month": 1,
+            "expiry_year": 2024,
+            "cardholder_name": "Joe Bloggs"
+          }
+        },
+        "created_at": "2023-08-18T21:13:07.18821Z",
+        "captured_at": "2023-08-18T21:13:09.477933Z"
+      }
+    ],
     "checkout": {
       "url": "https://magnificent-entremet-7ae0c6.netlify.app/default/overlay?_ptxn=txn_01hen7bxc1p8ep4yk7n5jbzk9r"
     }

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -967,6 +967,26 @@
           },
           "created_at": "2023-08-18T21:13:07.18821Z",
           "captured_at": "2023-08-18T21:13:09.477933Z"
+        },
+        {
+          "payment_attempt_id": "1f8e8302-b6fa-4290-b457-4c201eb3d53f",
+          "payment_method_id": null,
+          "stored_payment_method_id": "5f85a637-efa7-4c6b-88ec-9cc05301bb48",
+          "amount": "40000",
+          "status": "captured",
+          "error_code": null,
+          "method_details": {
+            "type": "card",
+            "card": {
+              "type": "visa",
+              "last4": "4242",
+              "expiry_month": 1,
+              "expiry_year": 2024,
+              "cardholder_name": "Joe Bloggs"
+            }
+          },
+          "created_at": "2023-08-18T21:13:07.18821Z",
+          "captured_at": "2023-08-18T21:13:09.477933Z"
         }
       ],
       "checkout": {


### PR DESCRIPTION
### Added
- Test coverage and CHANGELOG for nullable `payment_method_id`