### PR TITLE
docs(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## [1.2.0] - 2024-09-18
 
 ### Added
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,15 @@
 # Upgrading
 
-All breaking changes prior to v1 will be documented in this file to assist with upgrading. 
+All breaking changes will be documented in this file to assist with upgrading.
+
+## v1.2.0
+
+Upgrading to this version introduces 2 changes that may require action
+
+1. `\Paddle\SDK\Entities\Shared\TransactionPaymentAttempt` field `paymentMethodId` was `string` only,
+but has been aligned with the API to be `string` or `null`.
+
+2. `\Paddle\SDK\Resources\PricingPreviews\Operations` field `items` has been aligned with the API and can no longer be empty.
 
 ## v1.0.0
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.1.2';
+    private const SDK_VERSION = '1.2.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;


### PR DESCRIPTION
Changes: https://github.com/PaddleHQ/paddle-php-sdk/compare/v1.1.2...release/v1.2.0

---

### Added

- Added `product` to `subscription.items[]`, see [related changelog](https://developer.paddle.com/changelog/2024/subscription-items-product?utm_source=dx&utm_medium=paddle-php-sdk)
- Support for `createdAt` and `updatedAt` on Subscription notification prices
- Support custom prices when updating and previewing subscriptions, see [related changelog](https://developer.paddle.com/changelog/2024/add-custom-items-subscription)
- `TransactionsClient::getInvoicePDF` now supports `disposition` parameter, see [related changelog](https://developer.paddle.com/changelog/2024/invoice-pdf-open-in-browser)
- Support notification settings pagination, see [related changelog](https://developer.paddle.com/changelog/2024/notification-settings-pagination)
- Support notification settings `active` filter
- Support for `notification_id` on notification events

### Fixed
- `PreviewPrice` operation no longer allows empty `items`
- Transaction `payment_method_id` can be `string` or `null`

---

### Upgrade Notes

Upgrading to this version introduces 2 changes that may require action

1. `\Paddle\SDK\Entities\Shared\TransactionPaymentAttempt` field `paymentMethodId` was `string` only,
but has been aligned with the API to be `string` or `null`.

2. `\Paddle\SDK\Resources\PricingPreviews\Operations` field `items` has been aligned with the API and can no longer be empty.