### PR TITLE
fix: Reference released version 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+# [1.3.1] - 2024-09-30
+
+### Fixed
+
+- Update version reference to match package version
+
 ## [1.3.0] - 2024-09-30
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.2.0';
+    private const SDK_VERSION = '1.3.1';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;


### PR DESCRIPTION
With `1.3.0` I forgot to correctly reference this in the client, this patch references the future package release of `1.3.1`

No consumer changes. 