### PR TITLE
Fix: Transaction Preview Price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - Dropped `receipt_data` on create and preview of a one-time charge for Subscriptions and Transactions
+- `TransactionsClient::preview()` `TransactionPreview` response now allows null price ID for non-catalog prices:
+  - `TransactionPreview` `items[]->price` can now return `Price` (with `id`) or `TransactionPreviewPrice` (with nullable `id`)
+  - `TransactionPreview` `details->lineItems[]->priceId` is now nullable
+
+### Added
+- `TransactionsClient::create()` now supports operation items with optional properties:
+  - `Resources\Transactions\Operations\Create\TransactionCreateItem`
+  - `Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice`
+- `TransactionsClient::update()` now supports operation items with optional properties:
+  - `Resources\Transactions\Operations\Update\TransactionUpdateItem`
+  - `Resources\Transactions\Operations\Update\TransactionUpdateItemWithPrice`
+- `TransactionsClient::preview()` now supports operation items with optional properties:
+  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice`
+  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId`
+
+### Deprecated
+- `TransactionsClient::create()` operation items have been deprecated:
+  - `Entities\Transaction\TransactionCreateItem`
+  - `Entities\Transaction\TransactionCreateItemWithPrice`
+- `TransactionsClient::update()` operation items have been deprecated:
+  - `Entities\Transaction\TransactionUpdateTransactionItem`
+- `TransactionsClient::preview()` operation items have been deprecated:
+  - `Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice`
+  - `Entities\Transaction\TransactionItemPreviewWithPriceId`
 
 # [1.3.1] - 2024-09-30
 

--- a/src/Entities/Price.php
+++ b/src/Entities/Price.php
@@ -27,7 +27,7 @@ class Price implements Entity
      * @param array<UnitPriceOverride> $unitPriceOverrides
      */
     private function __construct(
-        public string $id,
+        public string|null $id,
         public string $productId,
         public string|null $name,
         public string $description,

--- a/src/Entities/Shared/TransactionLineItemPreview.php
+++ b/src/Entities/Shared/TransactionLineItemPreview.php
@@ -16,7 +16,7 @@ use Paddle\SDK\Entities\Product;
 class TransactionLineItemPreview
 {
     private function __construct(
-        public string $priceId,
+        public string|null $priceId,
         public int $quantity,
         public string $taxRate,
         public UnitTotals $unitTotals,

--- a/src/Entities/Transaction/TransactionCreateItem.php
+++ b/src/Entities/Transaction/TransactionCreateItem.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItem
+ */
 class TransactionCreateItem
 {
     public function __construct(

--- a/src/Entities/Transaction/TransactionCreateItemWithPrice.php
+++ b/src/Entities/Transaction/TransactionCreateItemWithPrice.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
+
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice
+ */
 class TransactionCreateItemWithPrice
 {
     public function __construct(

--- a/src/Entities/Transaction/TransactionCreateItemWithPrice.php
+++ b/src/Entities/Transaction/TransactionCreateItemWithPrice.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
-
 /**
  * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice
  */

--- a/src/Entities/Transaction/TransactionItemPreviewWithNonCatalogPrice.php
+++ b/src/Entities/Transaction/TransactionItemPreviewWithNonCatalogPrice.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice
+ */
 class TransactionItemPreviewWithNonCatalogPrice
 {
     public function __construct(

--- a/src/Entities/Transaction/TransactionItemPreviewWithPrice.php
+++ b/src/Entities/Transaction/TransactionItemPreviewWithPrice.php
@@ -16,7 +16,7 @@ use Paddle\SDK\Entities\Price;
 class TransactionItemPreviewWithPrice
 {
     private function __construct(
-        public Price $price,
+        public Price|TransactionPreviewPrice $price,
         public int $quantity,
         public bool $includeInTotals,
         public TransactionProration|null $proration,
@@ -26,7 +26,7 @@ class TransactionItemPreviewWithPrice
     public static function from(array $data): self
     {
         return new self(
-            Price::from($data['price']),
+            isset($data['price']['id']) ? Price::from($data['price']) : TransactionPreviewPrice::from($data['price']),
             $data['quantity'],
             $data['include_in_totals'],
             isset($data['proration']) ? TransactionProration::from($data['proration']) : null,

--- a/src/Entities/Transaction/TransactionItemPreviewWithPriceId.php
+++ b/src/Entities/Transaction/TransactionItemPreviewWithPriceId.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId
+ */
 class TransactionItemPreviewWithPriceId
 {
     public function __construct(

--- a/src/Entities/Transaction/TransactionNonCatalogPrice.php
+++ b/src/Entities/Transaction/TransactionNonCatalogPrice.php
@@ -18,6 +18,9 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionNonCatalogPrice
+ */
 class TransactionNonCatalogPrice
 {
     /**

--- a/src/Entities/Transaction/TransactionNonCatalogPrice.php
+++ b/src/Entities/Transaction/TransactionNonCatalogPrice.php
@@ -19,7 +19,7 @@ use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
 /**
- * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionNonCatalogPrice
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPrice
  */
 class TransactionNonCatalogPrice
 {

--- a/src/Entities/Transaction/TransactionNonCatalogPriceWithProduct.php
+++ b/src/Entities/Transaction/TransactionNonCatalogPriceWithProduct.php
@@ -19,7 +19,7 @@ use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
 /**
- * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionNonCatalogPriceWithProduct
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPriceWithProduct
  */
 class TransactionNonCatalogPriceWithProduct
 {

--- a/src/Entities/Transaction/TransactionNonCatalogPriceWithProduct.php
+++ b/src/Entities/Transaction/TransactionNonCatalogPriceWithProduct.php
@@ -18,6 +18,9 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionNonCatalogPriceWithProduct
+ */
 class TransactionNonCatalogPriceWithProduct
 {
     /**

--- a/src/Entities/Transaction/TransactionNonCatalogProduct.php
+++ b/src/Entities/Transaction/TransactionNonCatalogProduct.php
@@ -14,6 +14,9 @@ namespace Paddle\SDK\Entities\Transaction;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\TaxCategory;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogProduct
+ */
 class TransactionNonCatalogProduct
 {
     public function __construct(

--- a/src/Entities/Transaction/TransactionPreviewPrice.php
+++ b/src/Entities/Transaction/TransactionPreviewPrice.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
  * |-------------------------------------------------------------|.
  */
 
-namespace Paddle\SDK\Entities;
+namespace Paddle\SDK\Entities\Transaction;
 
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+use Paddle\SDK\Entities\Product;
 use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\ImportMeta;
@@ -21,13 +24,13 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
-class Price implements Entity
+class TransactionPreviewPrice implements Entity
 {
     /**
      * @param array<UnitPriceOverride> $unitPriceOverrides
      */
     private function __construct(
-        public string $id,
+        public string|null $id,
         public string $productId,
         public string|null $name,
         public string $description,

--- a/src/Entities/Transaction/TransactionUpdateTransactionItem.php
+++ b/src/Entities/Transaction/TransactionUpdateTransactionItem.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Transaction;
 
+/**
+ * @deprecated Replaced by \Paddle\SDK\Resources\Transactions\Operations\Update\TransactionUpdateItem
+ */
 class TransactionUpdateTransactionItem
 {
     public function __construct(

--- a/src/Resources/Transactions/Operations/Create/TransactionCreateItem.php
+++ b/src/Resources/Transactions/Operations/Create/TransactionCreateItem.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+
+class TransactionCreateItem
+{
+    public function __construct(
+        public string $priceId,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Transactions/Operations/Create/TransactionCreateItemWithPrice.php
+++ b/src/Resources/Transactions/Operations/Create/TransactionCreateItemWithPrice.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+
+class TransactionCreateItemWithPrice
+{
+    public function __construct(
+        public TransactionNonCatalogPrice|TransactionNonCatalogPriceWithProduct $price,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Transactions/Operations/Create/TransactionNonCatalogPrice.php
+++ b/src/Resources/Transactions/Operations/Create/TransactionNonCatalogPrice.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Money;
+use Paddle\SDK\Entities\Shared\PriceQuantity;
+use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
+use Paddle\SDK\Entities\Shared\UnitPriceOverride;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionNonCatalogPrice implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    /**
+     * @param array<UnitPriceOverride> $unitPriceOverrides
+     */
+    public function __construct(
+        public string $description,
+        public Money $unitPrice,
+        public string $productId,
+        public string|null|Undefined $name = new Undefined(),
+        public TimePeriod|null|Undefined $billingCycle = new Undefined(),
+        public TimePeriod|null|Undefined $trialPeriod = new Undefined(),
+        public TaxMode|Undefined $taxMode = new Undefined(),
+        public array|Undefined $unitPriceOverrides = new Undefined(),
+        public PriceQuantity|Undefined $quantity = new Undefined(),
+        public CustomData|null|Undefined $customData = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'description' => $this->description,
+            'unit_price' => $this->unitPrice,
+            'product_id' => $this->productId,
+            'name' => $this->name,
+            'billing_cycle' => $this->billingCycle,
+            'trial_period' => $this->trialPeriod,
+            'tax_mode' => $this->taxMode,
+            'unit_price_overrides' => $this->unitPriceOverrides,
+            'quantity' => $this->quantity,
+            'custom_data' => $this->customData,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/Create/TransactionNonCatalogPriceWithProduct.php
+++ b/src/Resources/Transactions/Operations/Create/TransactionNonCatalogPriceWithProduct.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Money;
+use Paddle\SDK\Entities\Shared\PriceQuantity;
+use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
+use Paddle\SDK\Entities\Shared\UnitPriceOverride;
+use Paddle\SDK\Entities\Transaction\TransactionNonCatalogProduct;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionNonCatalogPriceWithProduct implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    /**
+     * @param array<UnitPriceOverride> $unitPriceOverrides
+     */
+    public function __construct(
+        public string $description,
+        public Money $unitPrice,
+        public TransactionNonCatalogProduct $product,
+        public string|null|Undefined $name = new Undefined(),
+        public TimePeriod|null|Undefined $billingCycle = new Undefined(),
+        public TimePeriod|null|Undefined $trialPeriod = new Undefined(),
+        public TaxMode|Undefined $taxMode = new Undefined(),
+        public array|Undefined $unitPriceOverrides = new Undefined(),
+        public PriceQuantity|Undefined $quantity = new Undefined(),
+        public CustomData|null|Undefined $customData = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'description' => $this->description,
+            'unit_price' => $this->unitPrice,
+            'product' => $this->product,
+            'name' => $this->name,
+            'billing_cycle' => $this->billingCycle,
+            'trial_period' => $this->trialPeriod,
+            'tax_mode' => $this->taxMode,
+            'unit_price_overrides' => $this->unitPriceOverrides,
+            'quantity' => $this->quantity,
+            'custom_data' => $this->customData,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/CreateTransaction.php
+++ b/src/Resources/Transactions/Operations/CreateTransaction.php
@@ -10,10 +10,12 @@ use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\TransactionStatus;
-use Paddle\SDK\Entities\Transaction\TransactionCreateItem;
-use Paddle\SDK\Entities\Transaction\TransactionCreateItemWithPrice;
+use Paddle\SDK\Entities\Transaction\TransactionCreateItem as EntityTransactionCreateItem;
+use Paddle\SDK\Entities\Transaction\TransactionCreateItemWithPrice as EntityTransactionCreateItemWithPrice;
 use Paddle\SDK\Entities\Transaction\TransactionTimePeriod;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItem;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class CreateTransaction implements \JsonSerializable
@@ -21,7 +23,7 @@ class CreateTransaction implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<TransactionCreateItem|TransactionCreateItemWithPrice> $items
+     * @param array<TransactionCreateItem|TransactionCreateItemWithPrice|EntityTransactionCreateItem|EntityTransactionCreateItemWithPrice> $items
      */
     public function __construct(
         public readonly array $items,

--- a/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithNonCatalogPrice.php
+++ b/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithNonCatalogPrice.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Preview;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionNonCatalogPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionNonCatalogPriceWithProduct;
+use Paddle\SDK\Undefined;
+
+class TransactionItemPreviewWithNonCatalogPrice implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public TransactionNonCatalogPrice|TransactionNonCatalogPriceWithProduct $price,
+        public int $quantity,
+        public bool|Undefined $includeInTotals = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'price' => $this->price,
+            'quantity' => $this->quantity,
+            'include_in_totals' => $this->includeInTotals,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithNonCatalogPrice.php
+++ b/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithNonCatalogPrice.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Paddle\SDK\Resources\Transactions\Operations\Preview;
 
 use Paddle\SDK\FiltersUndefined;
-use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionNonCatalogPrice;
-use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionNonCatalogPriceWithProduct;
+use Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPriceWithProduct;
 use Paddle\SDK\Undefined;
 
 class TransactionItemPreviewWithNonCatalogPrice implements \JsonSerializable

--- a/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithPriceId.php
+++ b/src/Resources/Transactions/Operations/Preview/TransactionItemPreviewWithPriceId.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Preview;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionItemPreviewWithPriceId implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public string $priceId,
+        public int $quantity,
+        public bool|Undefined $includeInTotals = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'price_id' => $this->priceId,
+            'quantity' => $this->quantity,
+            'include_in_totals' => $this->includeInTotals,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/PreviewTransaction.php
+++ b/src/Resources/Transactions/Operations/PreviewTransaction.php
@@ -7,9 +7,11 @@ namespace Paddle\SDK\Resources\Transactions\Operations;
 use Paddle\SDK\Entities\Shared\AddressPreview;
 use Paddle\SDK\Entities\Shared\CollectionMode;
 use Paddle\SDK\Entities\Shared\CurrencyCode;
-use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice;
-use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPriceId;
+use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice as EntityItemPreviewWithNonCatalogPrice;
+use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPriceId as EntityItemPreviewWithPriceId;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId;
 use Paddle\SDK\Undefined;
 
 class PreviewTransaction implements \JsonSerializable
@@ -17,7 +19,7 @@ class PreviewTransaction implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<TransactionItemPreviewWithPriceId|TransactionItemPreviewWithNonCatalogPrice> $items
+     * @param array<TransactionItemPreviewWithPriceId|TransactionItemPreviewWithNonCatalogPrice|EntityItemPreviewWithPriceId|EntityItemPreviewWithNonCatalogPrice> $items
      */
     public function __construct(
         public readonly array $items,

--- a/src/Resources/Transactions/Operations/Price/TransactionNonCatalogPrice.php
+++ b/src/Resources/Transactions/Operations/Price/TransactionNonCatalogPrice.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+namespace Paddle\SDK\Resources\Transactions\Operations\Price;
 
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
@@ -24,13 +24,13 @@ class TransactionNonCatalogPrice implements \JsonSerializable
         public string $description,
         public Money $unitPrice,
         public string $productId,
-        public string|null|Undefined $name = new Undefined(),
-        public TimePeriod|null|Undefined $billingCycle = new Undefined(),
-        public TimePeriod|null|Undefined $trialPeriod = new Undefined(),
+        public string|Undefined|null $name = new Undefined(),
+        public TimePeriod|Undefined|null $billingCycle = new Undefined(),
+        public TimePeriod|Undefined|null $trialPeriod = new Undefined(),
         public TaxMode|Undefined $taxMode = new Undefined(),
         public array|Undefined $unitPriceOverrides = new Undefined(),
         public PriceQuantity|Undefined $quantity = new Undefined(),
-        public CustomData|null|Undefined $customData = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
     ) {
     }
 

--- a/src/Resources/Transactions/Operations/Price/TransactionNonCatalogPriceWithProduct.php
+++ b/src/Resources/Transactions/Operations/Price/TransactionNonCatalogPriceWithProduct.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+namespace Paddle\SDK\Resources\Transactions\Operations\Price;
 
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
@@ -10,7 +10,6 @@ use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
-use Paddle\SDK\Entities\Transaction\TransactionNonCatalogProduct;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Undefined;
 
@@ -25,13 +24,13 @@ class TransactionNonCatalogPriceWithProduct implements \JsonSerializable
         public string $description,
         public Money $unitPrice,
         public TransactionNonCatalogProduct $product,
-        public string|null|Undefined $name = new Undefined(),
-        public TimePeriod|null|Undefined $billingCycle = new Undefined(),
-        public TimePeriod|null|Undefined $trialPeriod = new Undefined(),
+        public string|Undefined|null $name = new Undefined(),
+        public TimePeriod|Undefined|null $billingCycle = new Undefined(),
+        public TimePeriod|Undefined|null $trialPeriod = new Undefined(),
         public TaxMode|Undefined $taxMode = new Undefined(),
         public array|Undefined $unitPriceOverrides = new Undefined(),
         public PriceQuantity|Undefined $quantity = new Undefined(),
-        public CustomData|null|Undefined $customData = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
     ) {
     }
 

--- a/src/Resources/Transactions/Operations/Price/TransactionNonCatalogProduct.php
+++ b/src/Resources/Transactions/Operations/Price/TransactionNonCatalogProduct.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Price;
+
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\TaxCategory;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionNonCatalogProduct implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public string $name,
+        public TaxCategory $taxCategory,
+        public string|Undefined|null $description = new Undefined(),
+        public string|Undefined|null $imageUrl = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'name' => $this->name,
+            'description' => $this->description,
+            'tax_category' => $this->taxCategory,
+            'image_url' => $this->imageUrl,
+            'custom_data' => $this->customData,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/Update/TransactionUpdateItem.php
+++ b/src/Resources/Transactions/Operations/Update/TransactionUpdateItem.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Update;
+
+class TransactionUpdateItem
+{
+    public function __construct(
+        public string $priceId,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Transactions/Operations/Update/TransactionUpdateItemWithPrice.php
+++ b/src/Resources/Transactions/Operations/Update/TransactionUpdateItemWithPrice.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Transactions\Operations\Create;
+namespace Paddle\SDK\Resources\Transactions\Operations\Update;
 
 use Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPrice;
 use Paddle\SDK\Resources\Transactions\Operations\Price\TransactionNonCatalogPriceWithProduct;
 
-class TransactionCreateItemWithPrice
+class TransactionUpdateItemWithPrice
 {
     public function __construct(
         public TransactionNonCatalogPrice|TransactionNonCatalogPriceWithProduct $price,

--- a/src/Resources/Transactions/Operations/UpdateTransaction.php
+++ b/src/Resources/Transactions/Operations/UpdateTransaction.php
@@ -13,6 +13,8 @@ use Paddle\SDK\Entities\Shared\TransactionStatus;
 use Paddle\SDK\Entities\Transaction\TransactionTimePeriod;
 use Paddle\SDK\Entities\Transaction\TransactionUpdateTransactionItem;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Update\TransactionUpdateItem;
+use Paddle\SDK\Resources\Transactions\Operations\Update\TransactionUpdateItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class UpdateTransaction implements \JsonSerializable
@@ -20,7 +22,7 @@ class UpdateTransaction implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<TransactionUpdateTransactionItem> $items
+     * @param array<TransactionUpdateItem|TransactionUpdateItemWithPrice|TransactionUpdateTransactionItem> $items
      */
     public function __construct(
         public readonly TransactionStatus|Undefined $status = new Undefined(),

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -19,21 +19,26 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\TransactionStatus;
 use Paddle\SDK\Entities\Transaction;
-use Paddle\SDK\Entities\Transaction\TransactionCreateItem;
-use Paddle\SDK\Entities\Transaction\TransactionCreateItemWithPrice;
-use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice;
-use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPriceId;
-use Paddle\SDK\Entities\Transaction\TransactionNonCatalogPrice;
+use Paddle\SDK\Entities\Transaction\TransactionCreateItem as DeprecatedTransactionCreateItem;
+use Paddle\SDK\Entities\Transaction\TransactionCreateItemWithPrice as DeprecatedTransactionCreateItemWithPrice;
+use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice as DeprecatedTransactionItemPreviewWithNonCatalogPrice;
+use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPriceId as DeprecatedTransactionItemPreviewWithPriceId;
+use Paddle\SDK\Entities\Transaction\TransactionNonCatalogPrice as DeprecatedTransactionNonCatalogPrice;
 use Paddle\SDK\Environment;
 use Paddle\SDK\Options;
 use Paddle\SDK\Resources\Shared\Operations\List\Comparator;
 use Paddle\SDK\Resources\Shared\Operations\List\DateComparison;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItem;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionNonCatalogPrice;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
 use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
+use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId;
 use Paddle\SDK\Resources\Transactions\Operations\PreviewTransaction;
 use Paddle\SDK\Resources\Transactions\Operations\UpdateTransaction;
 use Paddle\SDK\Tests\Utils\ReadsFixtures;
@@ -137,11 +142,45 @@ class TransactionsClientTest extends TestCase
             self::readRawJsonFixture('request/create_basic'),
         ];
 
+        yield 'Basic Create (deprecated)' => [
+            new CreateTransaction(
+                items: [
+                    new DeprecatedTransactionCreateItem('pri_01he5kxqey1k8ankgef29cj4bv', 1),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/minimal_entity')),
+            self::readRawJsonFixture('request/create_basic'),
+        ];
+
         yield 'Create with non catalog price' => [
             new CreateTransaction(
                 items: [
                     new TransactionCreateItemWithPrice(
                         new TransactionNonCatalogPrice(
+                            'Annual (per seat)',
+                            new Money('30000', CurrencyCode::USD()),
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            'Annual (per seat)',
+                            new TimePeriod(Interval::Year(), 1),
+                            null,
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(10, 999),
+                            null,
+                        ),
+                        20,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/minimal_entity')),
+            self::readRawJsonFixture('request/create_with_non_catalog_price'),
+        ];
+
+        yield 'Create with non catalog price (deprecated)' => [
+            new CreateTransaction(
+                items: [
+                    new DeprecatedTransactionCreateItemWithPrice(
+                        new DeprecatedTransactionNonCatalogPrice(
                             'Annual (per seat)',
                             'Annual (per seat)',
                             new TimePeriod(Interval::Year(), 1),
@@ -465,11 +504,64 @@ class TransactionsClientTest extends TestCase
             self::readRawJsonFixture('request/preview_basic'),
         ];
 
+        yield 'Basic Preview (deprecated)' => [
+            new PreviewTransaction(
+                items: [
+                    new DeprecatedTransactionItemPreviewWithPriceId('pri_01he5kxqey1k8ankgef29cj4bv', 1, true),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
+            self::readRawJsonFixture('request/preview_basic'),
+        ];
+
         yield 'Preview with non catalog price' => [
             new PreviewTransaction(
                 items: [
                     new TransactionItemPreviewWithNonCatalogPrice(
                         new TransactionNonCatalogPrice(
+                            'Annual (per seat)',
+                            new Money('30000', CurrencyCode::USD()),
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            'Annual (per seat)',
+                            new TimePeriod(Interval::Year(), 1),
+                            null,
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(10, 999),
+                            null,
+                        ),
+                        20,
+                        true,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
+            self::readRawJsonFixture('request/preview_with_non_catalog_price'),
+        ];
+
+        yield 'Preview with basic non catalog price' => [
+            new PreviewTransaction(
+                items: [
+                    new TransactionItemPreviewWithNonCatalogPrice(
+                        new TransactionNonCatalogPrice(
+                            'Annual (per seat)',
+                            new Money('30000', CurrencyCode::USD()),
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                        ),
+                        20,
+                        true,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
+            self::readRawJsonFixture('request/preview_with_basic_non_catalog_price'),
+        ];
+
+        yield 'Preview with non catalog price (deprecated)' => [
+            new PreviewTransaction(
+                items: [
+                    new DeprecatedTransactionItemPreviewWithNonCatalogPrice(
+                        new DeprecatedTransactionNonCatalogPrice(
                             'Annual (per seat)',
                             'Annual (per seat)',
                             new TimePeriod(Interval::Year(), 1),

--- a/tests/Functional/Resources/Transactions/_fixtures/request/create_with_multiple_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/create_with_multiple_non_catalog_price_and_product.json
@@ -1,0 +1,49 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product": {
+                    "custom_data": [],
+                    "description": "Some description",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            }
+        },
+        {
+            "include_in_totals": true,
+            "price": {
+                "description": "Annual (per seat)",
+                "product": {
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                }
+            },
+            "quantity": 20
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/create_with_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/create_with_non_catalog_price_and_product.json
@@ -1,0 +1,34 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product": {
+                    "custom_data": [],
+                    "description": "Some description",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_basic_non_catalog_price.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_basic_non_catalog_price.json
@@ -1,0 +1,16 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                }
+            },
+            "include_in_totals": true
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_multiple_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_multiple_non_catalog_price_and_product.json
@@ -1,0 +1,50 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product": {
+                    "custom_data": [],
+                    "description": "Some description",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            },
+            "include_in_totals": true
+        },
+        {
+            "include_in_totals": true,
+            "price": {
+                "description": "Annual (per seat)",
+                "product": {
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                }
+            },
+            "quantity": 20
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_non_catalog_price_and_product.json
@@ -1,0 +1,35 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product": {
+                    "custom_data": [],
+                    "description": "Some description",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            },
+            "include_in_totals": true
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/update_with_catalog_price.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/update_with_catalog_price.json
@@ -1,0 +1,9 @@
+{
+  "status": "billed",
+  "items": [
+    {
+      "quantity": 1,
+      "price_id": "pri_01he5kxqey1k8ankgef29cj4bv"
+    }
+  ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/update_with_non_catalog_price.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/update_with_non_catalog_price.json
@@ -1,0 +1,28 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/update_with_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/update_with_non_catalog_price_and_product.json
@@ -1,0 +1,49 @@
+{
+    "items": [
+        {
+            "quantity": 20,
+            "price": {
+                "description": "Annual (per seat)",
+                "name": "Annual (per seat)",
+                "product": {
+                    "custom_data": [],
+                    "description": "Some description",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "billing_cycle": {
+                    "interval": "year",
+                    "frequency": 1
+                },
+                "trial_period": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 10,
+                    "maximum": 999
+                },
+                "custom_data": null
+            }
+        },
+        {
+            "include_in_totals": true,
+            "price": {
+                "description": "Annual (per seat)",
+                "product": {
+                    "name": "Annual (per seat)",
+                    "tax_category": "digital-goods"
+                },
+                "unit_price": {
+                    "amount": "30000",
+                    "currency_code": "USD"
+                }
+            },
+            "quantity": 20
+        }
+    ]
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
@@ -43,7 +43,7 @@
             },
             {
                 "price": {
-                    "id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                    "id": null,
                     "description": "One-time charge",
                     "name": "One-time charge",
                     "product_id": "pro_01gsz97mq9pa4fkyy0wqenepkz",
@@ -104,7 +104,7 @@
             },
             "line_items": [
                 {
-                    "price_id": "pri_01gsz8z1q1n00f12qt82y31smh",
+                    "price_id": null,
                     "quantity": 20,
                     "totals": {
                         "subtotal": "600000",

--- a/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
@@ -132,7 +132,7 @@
                     }
                 },
                 {
-                    "price_id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                    "price_id": "pri_01gsz8z1q1n00f12qt82y31smh",
                     "quantity": 1,
                     "totals": {
                         "subtotal": "19900",


### PR DESCRIPTION
### Fixed
- `TransactionsClient::preview()` `TransactionPreview` response now allows null price ID for non-catalog prices:
  - `TransactionPreview` `items[]->price` can now return `Price` (with `id`) or `TransactionPreviewPrice` (with nullable `id`)
  - `TransactionPreview` `details->lineItems[]->priceId` is now nullable

### Added
- `TransactionsClient::create()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Create\TransactionCreateItem`
  - `Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice`
- `TransactionsClient::update()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Update\TransactionUpdateItem`
  - `Resources\Transactions\Operations\Update\TransactionUpdateItemWithPrice`
- `TransactionsClient::preview()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice`
  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId`

### Deprecated
- `TransactionsClient::create()` operation items have been deprecated:
  - `Entities\Transaction\TransactionCreateItem`
  - `Entities\Transaction\TransactionCreateItemWithPrice`
- `TransactionsClient::update()` operation items have been deprecated:
  - `Entities\Transaction\TransactionUpdateTransactionItem`
- `TransactionsClient::preview()` operation items have been deprecated:
  - `Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice`
  - `Entities\Transaction\TransactionItemPreviewWithPriceId`

---

Relates to #87 and #88 