### PR TITLE
docs: Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [unreleased] - 2024-10-01
+## [1.4.0] - 2024-10-17
 
 ### Added
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -58,7 +58,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.3.1';
+    private const SDK_VERSION = '1.4.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;


### PR DESCRIPTION
Changes: https://github.com/PaddleHQ/paddle-php-sdk/compare/v1.3.1...docs/release-v1.4.0

---

### Added

- Added simulations api [related changelog](https://developer.paddle.com/changelog/2024/webhook-simulator?utm_source=dx&utm_medium=paddle-php-sdk)
- Added `traffic_source` property to `NotificationSetting` entity
- Support notification settings `traffic_source` filter
- Support new payment methods `offline`, `unknown`, `wire_transfer`
- Support `tax_rates_used` property on `Adjustment` entity
### Fixed
- Dropped `receipt_data` on create and preview of a one-time charge for Subscriptions and Transactions
- `TransactionsClient::preview()` `TransactionPreview` response now allows null IDs for non-catalog prices and products:
  - `items[]->price` can now return `Price` (with `id`) or `TransactionPreviewPrice` (with nullable `id`)
  - `details->lineItems[]->priceId` is now nullable
  - `items[]->priceId` is now nullable
  - `details->lineItems[]->product` can now return `Product` (with `id`) or `TransactionPreviewProduct` (with nullable `id`)
- Empty custom data array will now serialize to empty JSON object `{}`
- `EventsClient::list` and `Notification->payload` will now return `UndefinedEvent` for unknown event types.
### Added
- `TransactionsClient::create()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Create\TransactionCreateItem`
  - `Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice`
- `TransactionsClient::update()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Update\TransactionUpdateItem`
  - `Resources\Transactions\Operations\Update\TransactionUpdateItemWithPrice`
- `TransactionsClient::preview()` now supports operation items with optional properties:
  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice`
  - `Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId`
### Deprecated
- `TransactionsClient::create()` operation items have been deprecated:
  - `Entities\Transaction\TransactionCreateItem`
  - `Entities\Transaction\TransactionCreateItemWithPrice`
- `TransactionsClient::update()` operation items have been deprecated:
  - `Entities\Transaction\TransactionUpdateTransactionItem`
- `TransactionsClient::preview()` operation items have been deprecated:
  - `Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice`
  - `Entities\Transaction\TransactionItemPreviewWithPriceId`