### PR TITLE
feat: Add support for saved payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Added
+
+- Support for saved payment methods, see [related changelog](https://developer.paddle.com/changelog/2024/saved-payment-methods?utm_source=dx&utm_medium=paddle-php-sdk)
+  - `Client->paymentMethods->list()`
+  - `Client->paymentMethods->get()`
+  - `Client->paymentMethods->delete()`
+  - `Client->customers->createAuthToken()`
+
 ## [1.4.0] - 2024-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
   - `Client->paymentMethods->list()`
   - `Client->paymentMethods->get()`
   - `Client->paymentMethods->delete()`
-  - `Client->customers->createAuthToken()`
+  - `Client->customers->generateAuthToken()`
 
 ## [1.4.0] - 2024-10-17
 

--- a/examples/customer_auth_token.php
+++ b/examples/customer_auth_token.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$environment = Paddle\SDK\Environment::tryFrom(getenv('PADDLE_ENVIRONMENT') ?: '') ?? Paddle\SDK\Environment::SANDBOX;
+$apiKey = getenv('PADDLE_API_KEY') ?: null;
+$customerId = getenv('PADDLE_CUSTOMER_ID') ?: null;
+
+if (is_null($apiKey)) {
+    echo "You must provide the PADDLE_API_KEY in the environment:\n";
+    echo "PADDLE_API_KEY=your-key php examples/basic_usage.php\n";
+    exit(1);
+}
+
+$paddle = new Paddle\SDK\Client($apiKey, options: new Paddle\SDK\Options($environment));
+
+// ┌───
+// │ Create Customer Auth Token │
+// └────────────────────────────┘
+try {
+    $authToken = $paddle->customers->createAuthToken($customerId);
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo sprintf("Created Customer Auth Token: %s\n", $authToken->customerAuthToken);
+echo sprintf("  - Expires At: %s\n", $authToken->expiresAt->format(DATE_RFC3339_EXTENDED));

--- a/examples/customer_auth_token.php
+++ b/examples/customer_auth_token.php
@@ -23,7 +23,7 @@ $paddle = new Paddle\SDK\Client($apiKey, options: new Paddle\SDK\Options($enviro
 // │ Create Customer Auth Token │
 // └────────────────────────────┘
 try {
-    $authToken = $paddle->customers->createAuthToken($customerId);
+    $authToken = $paddle->customers->generateAuthToken($customerId);
 } catch (ApiError|MalformedResponse $e) {
     var_dump($e);
     exit;

--- a/examples/payment_methods.php
+++ b/examples/payment_methods.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+use Paddle\SDK\Resources\PaymentMethods\Operations\ListPaymentMethods;
+use Paddle\SDK\Resources\Shared\Operations\List\Pager;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$environment = Paddle\SDK\Environment::tryFrom(getenv('PADDLE_ENVIRONMENT') ?: '') ?? Paddle\SDK\Environment::SANDBOX;
+$apiKey = getenv('PADDLE_API_KEY') ?: null;
+$customerId = getenv('PADDLE_CUSTOMER_ID') ?: null;
+$paymentMethodId = getenv('PADDLE_PAYMENT_METHOD_ID') ?: null;
+
+if (is_null($apiKey)) {
+    echo "You must provide the PADDLE_API_KEY in the environment:\n";
+    echo "PADDLE_API_KEY=your-key php examples/basic_usage.php\n";
+    exit(1);
+}
+
+$paddle = new Paddle\SDK\Client($apiKey, options: new Paddle\SDK\Options($environment));
+
+// ┌───
+// │ List Payment Methods │
+// └──────────────────────┘
+try {
+    $paymentMethods = $paddle->paymentMethods->list(
+        $customerId,
+        new ListPaymentMethods(
+            pager: new Pager(perPage: 10),
+        ),
+    );
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo "List Payment Methods\n";
+
+foreach ($paymentMethods as $paymentMethod) {
+    echo sprintf("- %s:\n", $paymentMethod->id);
+    echo sprintf("  - Type: %s\n", $paymentMethod->type->getValue());
+
+    if ($paymentMethod->card) {
+        echo sprintf("  - Card Type: %s\n", $paymentMethod->card->type->getValue());
+        echo sprintf("  - Card Holder Name: %s\n", $paymentMethod->card->cardholderName);
+        echo sprintf("  - Card Last 4 Digits: %s\n", $paymentMethod->card->last4);
+        echo sprintf("  - Card Expiry Year: %d\n", $paymentMethod->card->expiryYear);
+        echo sprintf("  - Card Expiry Month: %d\n", $paymentMethod->card->expiryMonth);
+    }
+
+    if ($paymentMethod->paypal) {
+        echo sprintf("  - PayPal Reference: %s\n", $paymentMethod->paypal->reference);
+        echo sprintf("  - PayPal Email: %s\n", $paymentMethod->paypal->email);
+    }
+}
+
+// ┌───
+// │ Get Payment Method |
+// └────────────────────┘
+try {
+    $paymentMethod = $paddle->paymentMethods->get($customerId, $paymentMethodId);
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo sprintf("Get Payment Method: %s\n", $paymentMethod->id);
+echo sprintf("  - Type: %s\n", $paymentMethod->type->getValue());
+
+if ($paymentMethod->card) {
+    echo sprintf("  - Card Type: %s\n", $paymentMethod->card->type->getValue());
+    echo sprintf("  - Card Holder Name: %s\n", $paymentMethod->card->cardholderName);
+    echo sprintf("  - Card Last 4 Digits: %s\n", $paymentMethod->card->last4);
+    echo sprintf("  - Card Expiry Year: %d\n", $paymentMethod->card->expiryYear);
+    echo sprintf("  - Card Expiry Month: %d\n", $paymentMethod->card->expiryMonth);
+}
+
+if ($paymentMethod->paypal) {
+    echo sprintf("  - PayPal Reference: %s\n", $paymentMethod->paypal->reference);
+    echo sprintf("  - PayPal Email: %s\n", $paymentMethod->paypal->email);
+}
+
+// ┌───
+// │ Delete Payment Method |
+// └───────────────────────┘
+try {
+    $paddle->paymentMethods->delete($customerId, $paymentMethodId);
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo sprintf("Deleted Payment Method: %s\n", $paymentMethodId);
+echo sprintf("  - Type: %s\n", $paymentMethod->type->getValue());

--- a/src/Client.php
+++ b/src/Client.php
@@ -29,6 +29,7 @@ use Paddle\SDK\Resources\EventTypes\EventTypesClient;
 use Paddle\SDK\Resources\NotificationLogs\NotificationLogsClient;
 use Paddle\SDK\Resources\Notifications\NotificationsClient;
 use Paddle\SDK\Resources\NotificationSettings\NotificationSettingsClient;
+use Paddle\SDK\Resources\PaymentMethods\PaymentMethodsClient;
 use Paddle\SDK\Resources\Prices\PricesClient;
 use Paddle\SDK\Resources\PricingPreviews\PricingPreviewsClient;
 use Paddle\SDK\Resources\Products\ProductsClient;
@@ -75,6 +76,7 @@ class Client
     public readonly EventTypesClient $eventTypes;
     public readonly EventsClient $events;
     public readonly PricingPreviewsClient $pricingPreviews;
+    public readonly PaymentMethodsClient $paymentMethods;
     public readonly NotificationSettingsClient $notificationSettings;
     public readonly NotificationsClient $notifications;
     public readonly NotificationLogsClient $notificationLogs;
@@ -122,6 +124,7 @@ class Client
         $this->eventTypes = new EventTypesClient($this);
         $this->events = new EventsClient($this);
         $this->pricingPreviews = new PricingPreviewsClient($this);
+        $this->paymentMethods = new PaymentMethodsClient($this);
         $this->notificationSettings = new NotificationSettingsClient($this);
         $this->notifications = new NotificationsClient($this);
         $this->notificationLogs = new NotificationLogsClient($this);

--- a/src/Client.php
+++ b/src/Client.php
@@ -156,7 +156,7 @@ class Client
         return $this->requestRaw('PATCH', $uri, $payload);
     }
 
-    public function postRaw(string|UriInterface $uri, array|\JsonSerializable $payload = [], array|HasParameters $parameters = []): ResponseInterface
+    public function postRaw(string|UriInterface $uri, array|\JsonSerializable|null $payload = [], array|HasParameters $parameters = []): ResponseInterface
     {
         if ($parameters) {
             $parameters = $parameters instanceof HasParameters ? $parameters->getParameters() : $parameters;

--- a/src/Entities/Collections/PaymentMethodCollection.php
+++ b/src/Entities/Collections/PaymentMethodCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Collections;
+
+use Paddle\SDK\Entities\PaymentMethod;
+
+class PaymentMethodCollection extends Collection
+{
+    public static function from(array $itemsData, Paginator|null $paginator = null): self
+    {
+        return new self(
+            array_map(fn (array $item): PaymentMethod => PaymentMethod::from($item), $itemsData),
+            $paginator,
+        );
+    }
+
+    public function current(): PaymentMethod
+    {
+        return parent::current();
+    }
+}

--- a/src/Entities/CustomerAuthToken.php
+++ b/src/Entities/CustomerAuthToken.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities;
+
+use Paddle\SDK\Notifications\Entities\DateTime;
+use Paddle\SDK\Notifications\Entities\Entity;
+
+class CustomerAuthToken implements Entity
+{
+    private function __construct(
+        public string $customerAuthToken,
+        public \DateTimeInterface $expiresAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            customerAuthToken: $data['customer_auth_token'],
+            expiresAt: DateTime::from($data['expires_at']),
+        );
+    }
+}

--- a/src/Entities/PaymentMethod.php
+++ b/src/Entities/PaymentMethod.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities;
+
+use Paddle\SDK\Entities\Shared\Card;
+use Paddle\SDK\Entities\Shared\Paypal;
+use Paddle\SDK\Entities\Shared\SavedPaymentMethodOrigin;
+use Paddle\SDK\Entities\Shared\SavedPaymentMethodType;
+
+class PaymentMethod implements Entity
+{
+    private function __construct(
+        public string $id,
+        public string $customerId,
+        public string $addressId,
+        public SavedPaymentMethodType $type,
+        public Card|null $card,
+        public Paypal|null $paypal,
+        public SavedPaymentMethodOrigin $origin,
+        public \DateTimeInterface|null $savedAt,
+        public \DateTimeInterface|null $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            customerId: $data['customer_id'],
+            addressId: $data['address_id'],
+            type: SavedPaymentMethodType::from($data['type']),
+            card: isset($data['card']) ? Card::from($data['card']) : null,
+            paypal: isset($data['paypal']) ? Paypal::from($data['paypal']) : null,
+            origin: SavedPaymentMethodOrigin::from($data['origin']),
+            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
+            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+        );
+    }
+}

--- a/src/Entities/PaymentMethod.php
+++ b/src/Entities/PaymentMethod.php
@@ -26,8 +26,8 @@ class PaymentMethod implements Entity
         public Card|null $card,
         public Paypal|null $paypal,
         public SavedPaymentMethodOrigin $origin,
-        public \DateTimeInterface|null $savedAt,
-        public \DateTimeInterface|null $updatedAt,
+        public \DateTimeInterface $savedAt,
+        public \DateTimeInterface $updatedAt,
     ) {
     }
 
@@ -41,8 +41,8 @@ class PaymentMethod implements Entity
             card: isset($data['card']) ? Card::from($data['card']) : null,
             paypal: isset($data['paypal']) ? Paypal::from($data['paypal']) : null,
             origin: SavedPaymentMethodOrigin::from($data['origin']),
-            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
-            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            savedAt: DateTime::from($data['saved_at']),
+            updatedAt: DateTime::from($data['updated_at']),
         );
     }
 }

--- a/src/Entities/Shared/Paypal.php
+++ b/src/Entities/Shared/Paypal.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Shared;
+
+class Paypal
+{
+    private function __construct(
+        public string $email,
+        public string $reference,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            $data['email'],
+            $data['reference'],
+        );
+    }
+}

--- a/src/Entities/Shared/SavedPaymentMethodOrigin.php
+++ b/src/Entities/Shared/SavedPaymentMethodOrigin.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SavedPaymentMethodOrigin SavedDuringPurchase()
+ * @method static SavedPaymentMethodOrigin Subscription()
+ */
+final class SavedPaymentMethodOrigin extends PaddleEnum
+{
+    private const SavedDuringPurchase = 'saved_during_purchase';
+    private const Subscription = 'subscription';
+}

--- a/src/Entities/Shared/SavedPaymentMethodType.php
+++ b/src/Entities/Shared/SavedPaymentMethodType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SavedPaymentMethodType Alipay()
+ * @method static SavedPaymentMethodType ApplePay()
+ * @method static SavedPaymentMethodType Card()
+ * @method static SavedPaymentMethodType GooglePay()
+ * @method static SavedPaymentMethodType Paypal()
+ */
+final class SavedPaymentMethodType extends PaddleEnum
+{
+    private const Alipay = 'alipay';
+    private const ApplePay = 'apple_pay';
+    private const Card = 'card';
+    private const GooglePay = 'google_pay';
+    private const Paypal = 'paypal';
+}

--- a/src/Notifications/Entities/DeletedPaymentMethod.php
+++ b/src/Notifications/Entities/DeletedPaymentMethod.php
@@ -24,8 +24,8 @@ class DeletedPaymentMethod implements Entity
         public string $addressId,
         public SavedPaymentMethodType $type,
         public SavedPaymentMethodOrigin $origin,
-        public \DateTimeInterface|null $savedAt,
-        public \DateTimeInterface|null $updatedAt,
+        public \DateTimeInterface $savedAt,
+        public \DateTimeInterface $updatedAt,
         public SavedPaymentMethodDeletionReason $deletionReason,
     ) {
     }
@@ -38,8 +38,8 @@ class DeletedPaymentMethod implements Entity
             addressId: $data['address_id'],
             type: SavedPaymentMethodType::from($data['type']),
             origin: SavedPaymentMethodOrigin::from($data['origin']),
-            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
-            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            savedAt: DateTime::from($data['saved_at']),
+            updatedAt: DateTime::from($data['updated_at']),
             deletionReason: SavedPaymentMethodDeletionReason::from($data['deletion_reason']),
         );
     }

--- a/src/Notifications/Entities/DeletedPaymentMethod.php
+++ b/src/Notifications/Entities/DeletedPaymentMethod.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Notifications\Entities;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodDeletionReason;
+use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodOrigin;
+use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodType;
+
+class DeletedPaymentMethod implements Entity
+{
+    private function __construct(
+        public string $id,
+        public string $customerId,
+        public string $addressId,
+        public SavedPaymentMethodType $type,
+        public SavedPaymentMethodOrigin $origin,
+        public \DateTimeInterface|null $savedAt,
+        public \DateTimeInterface|null $updatedAt,
+        public SavedPaymentMethodDeletionReason $deletionReason,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            customerId: $data['customer_id'],
+            addressId: $data['address_id'],
+            type: SavedPaymentMethodType::from($data['type']),
+            origin: SavedPaymentMethodOrigin::from($data['origin']),
+            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
+            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            deletionReason: SavedPaymentMethodDeletionReason::from($data['deletion_reason']),
+        );
+    }
+}

--- a/src/Notifications/Entities/EntityFactory.php
+++ b/src/Notifications/Entities/EntityFactory.php
@@ -28,7 +28,7 @@ class EntityFactory
         $identifier = self::snakeToPascalCase(implode('_', $type));
 
         /** @var class-string<Entity> $entity */
-        $entity = sprintf('\Paddle\SDK\Notifications\Entities\%s', ucfirst($entity));
+        $entity = sprintf('\Paddle\SDK\Notifications\Entities\%s', $entity);
         if (! class_exists($entity)) {
             $entity = UndefinedEntity::class;
         }

--- a/src/Notifications/Entities/PaymentMethod.php
+++ b/src/Notifications/Entities/PaymentMethod.php
@@ -23,8 +23,8 @@ class PaymentMethod implements Entity
         public string $addressId,
         public SavedPaymentMethodType $type,
         public SavedPaymentMethodOrigin $origin,
-        public \DateTimeInterface|null $savedAt,
-        public \DateTimeInterface|null $updatedAt,
+        public \DateTimeInterface $savedAt,
+        public \DateTimeInterface $updatedAt,
     ) {
     }
 
@@ -36,8 +36,8 @@ class PaymentMethod implements Entity
             addressId: $data['address_id'],
             type: SavedPaymentMethodType::from($data['type']),
             origin: SavedPaymentMethodOrigin::from($data['origin']),
-            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
-            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            savedAt: DateTime::from($data['saved_at']),
+            updatedAt: DateTime::from($data['updated_at']),
         );
     }
 }

--- a/src/Notifications/Entities/PaymentMethod.php
+++ b/src/Notifications/Entities/PaymentMethod.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Notifications\Entities;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodOrigin;
+use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodType;
+
+class PaymentMethod implements Entity
+{
+    private function __construct(
+        public string $id,
+        public string $customerId,
+        public string $addressId,
+        public SavedPaymentMethodType $type,
+        public SavedPaymentMethodOrigin $origin,
+        public \DateTimeInterface|null $savedAt,
+        public \DateTimeInterface|null $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            customerId: $data['customer_id'],
+            addressId: $data['address_id'],
+            type: SavedPaymentMethodType::from($data['type']),
+            origin: SavedPaymentMethodOrigin::from($data['origin']),
+            savedAt: isset($data['saved_at']) ? DateTime::from($data['saved_at']) : null,
+            updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+        );
+    }
+}

--- a/src/Notifications/Entities/Shared/SavedPaymentMethodDeletionReason.php
+++ b/src/Notifications/Entities/Shared/SavedPaymentMethodDeletionReason.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Notifications\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SavedPaymentMethodDeletionReason ReplacedByNewerVersion()
+ * @method static SavedPaymentMethodDeletionReason Api()
+ */
+final class SavedPaymentMethodDeletionReason extends PaddleEnum
+{
+    private const ReplacedByNewerVersion = 'replaced_by_newer_version';
+    private const Api = 'api';
+}

--- a/src/Notifications/Entities/Shared/SavedPaymentMethodOrigin.php
+++ b/src/Notifications/Entities/Shared/SavedPaymentMethodOrigin.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Notifications\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SavedPaymentMethodOrigin SavedDuringPurchase()
+ * @method static SavedPaymentMethodOrigin Subscription()
+ */
+final class SavedPaymentMethodOrigin extends PaddleEnum
+{
+    private const SavedDuringPurchase = 'saved_during_purchase';
+    private const Subscription = 'subscription';
+}

--- a/src/Notifications/Entities/Shared/SavedPaymentMethodType.php
+++ b/src/Notifications/Entities/Shared/SavedPaymentMethodType.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Notifications\Entities\Shared;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static SavedPaymentMethodType Alipay()
+ * @method static SavedPaymentMethodType ApplePay()
+ * @method static SavedPaymentMethodType Card()
+ * @method static SavedPaymentMethodType GooglePay()
+ * @method static SavedPaymentMethodType Paypal()
+ */
+final class SavedPaymentMethodType extends PaddleEnum
+{
+    private const Alipay = 'alipay';
+    private const ApplePay = 'apple_pay';
+    private const Card = 'card';
+    private const GooglePay = 'google_pay';
+    private const Paypal = 'paypal';
+}

--- a/src/Notifications/Events/PaymentMethodDeleted.php
+++ b/src/Notifications/Events/PaymentMethodDeleted.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Events;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Entities\Event\EventTypeName;
+use Paddle\SDK\Notifications\Entities\DeletedPaymentMethod;
+use Paddle\SDK\Notifications\Entities\Entity;
+
+final class PaymentMethodDeleted extends Event
+{
+    private function __construct(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        public readonly DeletedPaymentMethod $paymentMethod,
+        string|null $notificationId,
+    ) {
+        parent::__construct($eventId, $eventType, $occurredAt, $paymentMethod, $notificationId);
+    }
+
+    /**
+     * @param DeletedPaymentMethod $data
+     */
+    public static function fromEvent(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        Entity $data,
+        string|null $notificationId = null,
+    ): static {
+        return new self($eventId, $eventType, $occurredAt, $data, $notificationId);
+    }
+}

--- a/src/Notifications/Events/PaymentMethodSaved.php
+++ b/src/Notifications/Events/PaymentMethodSaved.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Events;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Entities\Event\EventTypeName;
+use Paddle\SDK\Notifications\Entities\Entity;
+use Paddle\SDK\Notifications\Entities\PaymentMethod;
+
+final class PaymentMethodSaved extends Event
+{
+    private function __construct(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        public readonly PaymentMethod $paymentMethod,
+        string|null $notificationId,
+    ) {
+        parent::__construct($eventId, $eventType, $occurredAt, $paymentMethod, $notificationId);
+    }
+
+    /**
+     * @param PaymentMethod $data
+     */
+    public static function fromEvent(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        Entity $data,
+        string|null $notificationId = null,
+    ): static {
+        return new self($eventId, $eventType, $occurredAt, $data, $notificationId);
+    }
+}

--- a/src/Resources/Customers/CustomersClient.php
+++ b/src/Resources/Customers/CustomersClient.php
@@ -119,7 +119,7 @@ class CustomersClient
      * @throws ApiError\CustomerApiError On a customer specific API error
      * @throws MalformedResponse         If the API response was not parsable
      */
-    public function createAuthToken(string $id): CustomerAuthToken
+    public function generateAuthToken(string $id): CustomerAuthToken
     {
         $parser = new ResponseParser(
             $this->client->postRaw("/customers/{$id}/auth-token", null),

--- a/src/Resources/Customers/CustomersClient.php
+++ b/src/Resources/Customers/CustomersClient.php
@@ -16,6 +16,7 @@ use Paddle\SDK\Entities\Collections\CreditBalanceCollection;
 use Paddle\SDK\Entities\Collections\CustomerCollection;
 use Paddle\SDK\Entities\Collections\Paginator;
 use Paddle\SDK\Entities\Customer;
+use Paddle\SDK\Entities\CustomerAuthToken;
 use Paddle\SDK\Entities\Shared\Status;
 use Paddle\SDK\Exceptions\ApiError;
 use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
@@ -111,5 +112,19 @@ class CustomersClient
         );
 
         return CreditBalanceCollection::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError                  On a generic API error
+     * @throws ApiError\CustomerApiError On a customer specific API error
+     * @throws MalformedResponse         If the API response was not parsable
+     */
+    public function createAuthToken(string $id): CustomerAuthToken
+    {
+        $parser = new ResponseParser(
+            $this->client->postRaw("/customers/{$id}/auth-token"),
+        );
+
+        return CustomerAuthToken::from($parser->getData());
     }
 }

--- a/src/Resources/Customers/CustomersClient.php
+++ b/src/Resources/Customers/CustomersClient.php
@@ -122,7 +122,7 @@ class CustomersClient
     public function createAuthToken(string $id): CustomerAuthToken
     {
         $parser = new ResponseParser(
-            $this->client->postRaw("/customers/{$id}/auth-token"),
+            $this->client->postRaw("/customers/{$id}/auth-token", null),
         );
 
         return CustomerAuthToken::from($parser->getData());

--- a/src/Resources/PaymentMethods/Operations/ListPaymentMethods.php
+++ b/src/Resources/PaymentMethods/Operations/ListPaymentMethods.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\PaymentMethods\Operations;
+
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
+use Paddle\SDK\HasParameters;
+use Paddle\SDK\Resources\Shared\Operations\List\Pager;
+
+class ListPaymentMethods implements HasParameters
+{
+    /**
+     * @param array<string> $addressIds
+     *
+     * @throws InvalidArgumentException If addressIds contain the incorrect type
+     */
+    public function __construct(
+        private readonly Pager|null $pager = null,
+        private readonly array $addressIds = [],
+        private readonly bool|null $supportsCheckout = null,
+    ) {
+        if ($invalid = array_filter($this->addressIds, fn ($value): bool => ! is_string($value))) {
+            throw InvalidArgumentException::arrayContainsInvalidTypes('address_ids', 'string', implode(', ', $invalid));
+        }
+    }
+
+    public function getParameters(): array
+    {
+        return array_merge(
+            $this->pager?->getParameters() ?? [],
+            array_filter([
+                'address_id' => implode(',', $this->addressIds),
+                'supports_checkout' => isset($this->supportsCheckout) ? ($this->supportsCheckout ? 'true' : 'false') : null,
+            ]),
+        );
+    }
+}

--- a/src/Resources/PaymentMethods/PaymentMethodsClient.php
+++ b/src/Resources/PaymentMethods/PaymentMethodsClient.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\PaymentMethods;
+
+use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Collections\Paginator;
+use Paddle\SDK\Entities\Collections\PaymentMethodCollection;
+use Paddle\SDK\Entities\PaymentMethod;
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+use Paddle\SDK\Resources\PaymentMethods\Operations\ListPaymentMethods;
+use Paddle\SDK\ResponseParser;
+
+class PaymentMethodsClient
+{
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function list(string $customerId, ListPaymentMethods $listOperation = new ListPaymentMethods()): PaymentMethodCollection
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw("/customers/{$customerId}/payment-methods", $listOperation),
+        );
+
+        return PaymentMethodCollection::from(
+            $parser->getData(),
+            new Paginator($this->client, $parser->getPagination(), PaymentMethodCollection::class),
+        );
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function get(string $customerId, string $id): PaymentMethod
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw("/customers/{$customerId}/payment-methods/{$id}"),
+        );
+
+        return PaymentMethod::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function delete(string $customerId, string $id): void
+    {
+        new ResponseParser(
+            $this->client->deleteRaw("/customers/{$customerId}/payment-methods/{$id}"),
+        );
+    }
+}

--- a/tests/Functional/Resources/Customers/CustomersClientTest.php
+++ b/tests/Functional/Resources/Customers/CustomersClientTest.php
@@ -243,4 +243,30 @@ class CustomersClientTest extends TestCase
             sprintf('%s/customers/ctm_01h8441jn5pcwrfhwh78jqt8hk/credit-balances', Environment::SANDBOX->baseUrl()),
         ];
     }
+
+    /**
+     * @test
+     */
+    public function create_auth_token_hits_expected_uri_and_parses_response(): void
+    {
+        $expectedUri = sprintf('%s/customers/ctm_01h8441jn5pcwrfhwh78jqt8hk/auth-token', Environment::SANDBOX->baseUrl());
+        $response = new Response(200, body: self::readRawJsonFixture('response/auth_token'));
+
+        $this->mockClient->addResponse($response);
+        $authToken = $this->client->customers->createAuthToken('ctm_01h8441jn5pcwrfhwh78jqt8hk');
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+
+        self::assertSame(
+            'pca_01hwyzq8hmdwed5p4jc4hnv6bh_01hwwggymjn0yhhb2gr4p91276_6xaav4lydudt6bgmuefeaf2xnu3umegx',
+            $authToken->customerAuthToken,
+        );
+        self::assertSame(
+            '2024-05-03T10:34:12.345+00:00',
+            $authToken->expiresAt->format(DATE_RFC3339_EXTENDED),
+        );
+    }
 }

--- a/tests/Functional/Resources/Customers/CustomersClientTest.php
+++ b/tests/Functional/Resources/Customers/CustomersClientTest.php
@@ -258,6 +258,7 @@ class CustomersClientTest extends TestCase
 
         self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals('POST', $request->getMethod());
+        self::assertSame('', (string) $request->getBody());
         self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
 
         self::assertSame(

--- a/tests/Functional/Resources/Customers/CustomersClientTest.php
+++ b/tests/Functional/Resources/Customers/CustomersClientTest.php
@@ -253,7 +253,7 @@ class CustomersClientTest extends TestCase
         $response = new Response(200, body: self::readRawJsonFixture('response/auth_token'));
 
         $this->mockClient->addResponse($response);
-        $authToken = $this->client->customers->createAuthToken('ctm_01h8441jn5pcwrfhwh78jqt8hk');
+        $authToken = $this->client->customers->generateAuthToken('ctm_01h8441jn5pcwrfhwh78jqt8hk');
         $request = $this->mockClient->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);

--- a/tests/Functional/Resources/Customers/_fixtures/response/auth_token.json
+++ b/tests/Functional/Resources/Customers/_fixtures/response/auth_token.json
@@ -1,0 +1,9 @@
+{
+    "data": {
+        "customer_auth_token": "pca_01hwyzq8hmdwed5p4jc4hnv6bh_01hwwggymjn0yhhb2gr4p91276_6xaav4lydudt6bgmuefeaf2xnu3umegx",
+        "expires_at": "2024-05-03T10:34:12.345Z"
+    },
+    "meta": {
+        "request_id": "fa176777-4bca-49ec-aa1e-f53885333cb7"
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
+++ b/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
@@ -252,3 +252,6 @@ class PaymentMethodsClientTest extends TestCase
         self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
     }
 }
+
+
+

--- a/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
+++ b/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Functional\Resources\PaymentMethods;
+
+use GuzzleHttp\Psr7\Response;
+use Http\Mock\Client as MockClient;
+use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Shared\SavedPaymentMethodOrigin;
+use Paddle\SDK\Environment;
+use Paddle\SDK\Options;
+use Paddle\SDK\Resources\PaymentMethods\Operations\ListPaymentMethods;
+use Paddle\SDK\Resources\Shared\Operations\List\OrderBy;
+use Paddle\SDK\Resources\Shared\Operations\List\Pager;
+use Paddle\SDK\Tests\Utils\ReadsFixtures;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class PaymentMethodsClientTest extends TestCase
+{
+    use ReadsFixtures;
+
+    private MockClient $mockClient;
+    private Client $client;
+
+    public function setUp(): void
+    {
+        $this->mockClient = new MockClient();
+        $this->client = new Client(
+            apiKey: 'API_KEY_PLACEHOLDER',
+            options: new Options(Environment::SANDBOX),
+            httpClient: $this->mockClient);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider listOperationsProvider
+     */
+    public function list_hits_expected_uri(
+        string $customerId,
+        ListPaymentMethods $listOperation,
+        string $expectedUri,
+    ): void {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/list_default')));
+        $this->client->paymentMethods->list($customerId, $listOperation);
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+    }
+
+    public static function listOperationsProvider(): \Generator
+    {
+        yield 'Default' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(),
+            sprintf('%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'List by address IDs' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                addressIds: ['add_01hv8h6jj90jjz0d71m6hj4r9z', 'add_02hv8h6jj90jjz0d71m6hj4r9z'],
+            ),
+            sprintf(
+                '%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?address_id=add_01hv8h6jj90jjz0d71m6hj4r9z,add_02hv8h6jj90jjz0d71m6hj4r9z',
+                Environment::SANDBOX->baseUrl(),
+            ),
+        ];
+
+        yield 'List supports_checkout false' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                supportsCheckout: false,
+            ),
+            sprintf('%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?supports_checkout=false', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'List supports_checkout true' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                supportsCheckout: true,
+            ),
+            sprintf('%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?supports_checkout=true', Environment::SANDBOX->baseUrl()),
+        ];
+
+        yield 'List by address IDs and supports_checkout' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                addressIds: ['add_01hv8h6jj90jjz0d71m6hj4r9z', 'add_02hv8h6jj90jjz0d71m6hj4r9z'],
+                supportsCheckout: true,
+            ),
+            sprintf(
+                '%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?address_id=add_01hv8h6jj90jjz0d71m6hj4r9z,add_02hv8h6jj90jjz0d71m6hj4r9z&supports_checkout=true',
+                Environment::SANDBOX->baseUrl(),
+            ),
+        ];
+
+        yield 'List payment-methods with pagination' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                pager: new Pager(),
+            ),
+            sprintf(
+                '%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?order_by=id[asc]&per_page=50',
+                Environment::SANDBOX->baseUrl(),
+            ),
+        ];
+
+        yield 'List payment-methods with pagination after' => [
+            'ctm_01hv6y1jedq4p1n0yqn5ba3ky4',
+            new ListPaymentMethods(
+                pager: new Pager(
+                    after: 'paymtd_01hs8zx6x377xfsfrt2bqsevbw',
+                    orderBy: OrderBy::idDescending(),
+                    perPage: 100,
+                ),
+            ),
+            sprintf(
+                '%s/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?after=paymtd_01hs8zx6x377xfsfrt2bqsevbw&order_by=id[desc]&per_page=100',
+                Environment::SANDBOX->baseUrl(),
+            ),
+        ];
+    }
+
+    /** @test */
+    public function it_can_paginate(): void
+    {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/list_paginated_page_one')));
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/list_paginated_page_two')));
+
+        $collection = $this->client->paymentMethods->list('ctm_01hv6y1jedq4p1n0yqn5ba3ky4');
+
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertEquals(
+            Environment::SANDBOX->baseUrl() . '/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods',
+            urldecode((string) $request->getUri()),
+        );
+
+        $allPaymentMethods = iterator_to_array($collection);
+        self::assertCount(4, $allPaymentMethods);
+
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertEquals(
+            Environment::SANDBOX->baseUrl() . '/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?after=paymtd_02hs8zx6x377xfsfrt2bqsevbw',
+            urldecode((string) $request->getUri()),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function get_payment_methods_returns_expected_card_response(): void
+    {
+        $customerId = 'ctm_01hv6y1jedq4p1n0yqn5ba3ky4';
+        $paymentMethodId = 'paymtd_01hs8zx6x377xfsfrt2bqsevbw';
+        $expectedUri = sprintf(
+            '%s/customers/%s/payment-methods/%s',
+            Environment::SANDBOX->baseUrl(),
+            $customerId,
+            $paymentMethodId,
+        );
+        $response = new Response(200, body: self::readRawJsonFixture('response/full_entity_card'));
+
+        $this->mockClient->addResponse($response);
+        $paymentMethod = $this->client->paymentMethods->get($customerId, $paymentMethodId);
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+
+        self::assertSame($paymentMethodId, $paymentMethod->id);
+        self::assertSame($customerId, $paymentMethod->customerId);
+        self::assertSame('add_01hv8h6jj90jjz0d71m6hj4r9z', $paymentMethod->addressId);
+        self::assertNull($paymentMethod->paypal);
+        self::assertEquals(SavedPaymentMethodOrigin::Subscription(), $paymentMethod->origin);
+        self::assertSame('2024-05-03T11:50:23.422+00:00', $paymentMethod->savedAt->format(DATE_RFC3339_EXTENDED));
+        self::assertSame('2024-05-04T11:50:23.422+00:00', $paymentMethod->updatedAt->format(DATE_RFC3339_EXTENDED));
+
+        $card = $paymentMethod->card;
+        self::assertEquals('visa', $card->type);
+        self::assertEquals('0002', $card->last4);
+        self::assertEquals(1, $card->expiryMonth);
+        self::assertEquals(2025, $card->expiryYear);
+        self::assertEquals('Sam Miller', $card->cardholderName);
+    }
+
+    /**
+     * @test
+     */
+    public function get_payment_methods_returns_expected_paypal_response(): void
+    {
+        $customerId = 'ctm_01hv6y1jedq4p1n0yqn5ba3ky4';
+        $paymentMethodId = 'paymtd_01hs8zx6x377xfsfrt2bqsevbw';
+        $expectedUri = sprintf(
+            '%s/customers/%s/payment-methods/%s',
+            Environment::SANDBOX->baseUrl(),
+            $customerId,
+            $paymentMethodId,
+        );
+        $response = new Response(200, body: self::readRawJsonFixture('response/full_entity_paypal'));
+
+        $this->mockClient->addResponse($response);
+        $paymentMethod = $this->client->paymentMethods->get($customerId, $paymentMethodId);
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+
+        self::assertSame($paymentMethodId, $paymentMethod->id);
+        self::assertSame($customerId, $paymentMethod->customerId);
+        self::assertSame('add_01hv8h6jj90jjz0d71m6hj4r9z', $paymentMethod->addressId);
+        self::assertNull($paymentMethod->card);
+        self::assertEquals(SavedPaymentMethodOrigin::SavedDuringPurchase(), $paymentMethod->origin);
+        self::assertSame('2024-05-03T11:50:23.422+00:00', $paymentMethod->savedAt->format(DATE_RFC3339_EXTENDED));
+        self::assertSame('2024-05-04T11:50:23.422+00:00', $paymentMethod->updatedAt->format(DATE_RFC3339_EXTENDED));
+
+        $paypal = $paymentMethod->paypal;
+        self::assertEquals('sam@example.com', $paypal->email);
+        self::assertEquals('some-reference', $paypal->reference);
+    }
+
+    /** @test */
+    public function delete_hits_expected_uri(): void
+    {
+        $customerId = 'ctm_01hv6y1jedq4p1n0yqn5ba3ky4';
+        $paymentMethodId = 'paymtd_01hs8zx6x377xfsfrt2bqsevbw';
+        $expectedUri = sprintf(
+            '%s/customers/%s/payment-methods/%s',
+            Environment::SANDBOX->baseUrl(),
+            $customerId,
+            $paymentMethodId,
+        );
+
+        $this->mockClient->addResponse(new Response(204));
+        $this->client->paymentMethods->delete($customerId, $paymentMethodId);
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('DELETE', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
+++ b/tests/Functional/Resources/PaymentMethods/PaymentMethodsClientTest.php
@@ -252,6 +252,3 @@ class PaymentMethodsClientTest extends TestCase
         self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
     }
 }
-
-
-

--- a/tests/Functional/Resources/PaymentMethods/_fixtures/response/full_entity_card.json
+++ b/tests/Functional/Resources/PaymentMethods/_fixtures/response/full_entity_card.json
@@ -1,0 +1,22 @@
+{
+    "data": {
+        "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+        "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+        "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+        "type": "card",
+        "card": {
+            "type": "visa",
+            "last4": "0002",
+            "expiry_month": 1,
+            "expiry_year": 2025,
+            "cardholder_name": "Sam Miller"
+        },
+        "paypal": null,
+        "origin": "subscription",
+        "saved_at": "2024-05-03T11:50:23.422Z",
+        "updated_at": "2024-05-04T11:50:23.422Z"
+    },
+    "meta": {
+        "request_id": "03dae283-b7e9-47dc-b8c0-229576d90139"
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/_fixtures/response/full_entity_paypal.json
+++ b/tests/Functional/Resources/PaymentMethods/_fixtures/response/full_entity_paypal.json
@@ -1,0 +1,19 @@
+{
+    "data": {
+        "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+        "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+        "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+        "type": "paypal",
+        "card": null,
+        "paypal": {
+            "email": "sam@example.com",
+            "reference": "some-reference"
+        },
+        "origin": "saved_during_purchase",
+        "saved_at": "2024-05-03T11:50:23.422Z",
+        "updated_at": "2024-05-04T11:50:23.422Z"
+    },
+    "meta": {
+        "request_id": "03dae283-b7e9-47dc-b8c0-229576d90139"
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_default.json
@@ -1,0 +1,47 @@
+{
+    "data": [
+        {
+            "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        },
+        {
+            "id": "paymtd_02hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        }
+    ],
+    "meta": {
+        "request_id": "f831dd0b-150d-41c8-a952-5f8f84dbdcee",
+        "pagination": {
+            "per_page": 2,
+            "next": "https://api.paddle.com/customers/ctm_01h282ye3v2d9cmcm8dzpawrd0/payment-methods?after=paymtd_02hs8zx6x377xfsfrt2bqsevbw",
+            "has_more": false,
+            "estimated_total": 1
+        }
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_paginated_page_one.json
@@ -1,0 +1,47 @@
+{
+    "data": [
+        {
+            "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        },
+        {
+            "id": "paymtd_02hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        }
+    ],
+    "meta": {
+        "request_id": "f831dd0b-150d-41c8-a952-5f8f84dbdcee",
+        "pagination": {
+            "per_page": 2,
+            "next": "https://sandbox-api.paddle.com/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?after=paymtd_02hs8zx6x377xfsfrt2bqsevbw",
+            "has_more": true,
+            "estimated_total": 4
+        }
+    }
+}

--- a/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/PaymentMethods/_fixtures/response/list_paginated_page_two.json
@@ -1,0 +1,47 @@
+{
+    "data": [
+        {
+            "id": "paymtd_03hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        },
+        {
+            "id": "paymtd_04hs8zx6x377xfsfrt2bqsevbw",
+            "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+            "address_id": "add_01hv8h6jj90jjz0d71m6hj4r9z",
+            "type": "card",
+            "card": {
+                "type": "visa",
+                "last4": "0002",
+                "expiry_month": 1,
+                "expiry_year": 2025
+            },
+            "cardholder_name": "Sam Miller",
+            "paypal": null,
+            "origin": "saved_during_purchase",
+            "saved_at": "2024-05-03T11:50:23.422Z",
+            "updated_at": "2024-05-03T11:50:23.422Z"
+        }
+    ],
+    "meta": {
+        "request_id": "f831dd0b-150d-41c8-a952-5f8f84dbdcee",
+        "pagination": {
+            "per_page": 2,
+            "next": "https://sandbox-api.paddle.com/customers/ctm_01hv6y1jedq4p1n0yqn5ba3ky4/payment-methods?after=paymtd_04hs8zx6x377xfsfrt2bqsevbw",
+            "has_more": false,
+            "estimated_total": 4
+        }
+    }
+}

--- a/tests/Unit/Entities/_fixtures/notification/entity/payment_method.deleted.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/payment_method.deleted.json
@@ -1,0 +1,10 @@
+{
+    "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+    "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+    "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+    "deletion_reason": "replaced_by_newer_version",
+    "type": "card",
+    "origin": "saved_during_purchase",
+    "saved_at": "2024-05-02T02:55:25.198953Z",
+    "updated_at": "2024-05-03T12:24:18.826338Z"
+}

--- a/tests/Unit/Entities/_fixtures/notification/entity/payment_method.saved.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/payment_method.saved.json
@@ -1,0 +1,9 @@
+{
+    "id": "paymtd_01hs8zx6x377xfsfrt2bqsevbw",
+    "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+    "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+    "type": "card",
+    "origin": "saved_during_purchase",
+    "saved_at": "2024-05-02T02:55:25.198953Z",
+    "updated_at": "2024-05-02T02:55:25.198953Z"
+}


### PR DESCRIPTION
### Added

- Support for saved payment methods, see [related changelog](https://developer.paddle.com/changelog/2024/saved-payment-methods?utm_source=dx&utm_medium=paddle-php-sdk)
  - `Client->paymentMethods->list()`
  - `Client->paymentMethods->get()`
  - `Client->paymentMethods->delete()`
  - `Client->customers->generateAuthToken()`