### PR TITLE
fix: Notification replay now calls correct endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Fixed
+
+- `Client->notifications->replay()` now calls the correct endpoint
+
 ## [1.5.0] - 2024-11-18
 
 ### Added

--- a/examples/notification_replay.php
+++ b/examples/notification_replay.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$environment = Paddle\SDK\Environment::tryFrom(getenv('PADDLE_ENVIRONMENT') ?: '') ?? Paddle\SDK\Environment::SANDBOX;
+$apiKey = getenv('PADDLE_API_KEY') ?: null;
+$notificationId = getenv('PADDLE_NOTIFICATION_ID') ?: null;
+
+if (is_null($apiKey)) {
+    echo "You must provide the PADDLE_API_KEY in the environment:\n";
+    echo "PADDLE_API_KEY=your-key php examples/basic_usage.php\n";
+    exit(1);
+}
+
+$paddle = new Paddle\SDK\Client($apiKey, options: new Paddle\SDK\Options($environment));
+
+// ┌───
+// │ Replay Notification │
+// └─────────────────────┘
+try {
+    $replayedNotificationId = $paddle->notifications->replay($notificationId);
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo sprintf("Replayed Notification ID: %s\n", $replayedNotificationId);

--- a/src/Resources/Notifications/NotificationsClient.php
+++ b/src/Resources/Notifications/NotificationsClient.php
@@ -63,7 +63,7 @@ class NotificationsClient
     public function replay(string $id): string
     {
         $parser = new ResponseParser(
-            $this->client->postRaw("/notifications/{$id}"),
+            $this->client->postRaw("/notifications/{$id}/replay"),
         );
 
         $data = $parser->getData();

--- a/tests/Functional/Resources/Notifications/NotificationsClientTest.php
+++ b/tests/Functional/Resources/Notifications/NotificationsClientTest.php
@@ -170,7 +170,7 @@ class NotificationsClientTest extends TestCase
         self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals('POST', $request->getMethod());
         self::assertEquals(
-            sprintf('%s/notifications/nft_01h8441jn5pcwrfhwh78jqt8hk', Environment::SANDBOX->baseUrl()),
+            sprintf('%s/notifications/nft_01h8441jn5pcwrfhwh78jqt8hk/replay', Environment::SANDBOX->baseUrl()),
             urldecode((string) $request->getUri()),
         );
         self::assertSame('ntf_01h46h1s2zabpkdks7yt4vkgkc', $replayId);


### PR DESCRIPTION
### Fixed
- `Client->notifications->replay()` now calls the correct endpoint