### PR TITLE
fix: Add proration to transation line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 ### Fixed
 
 - `Client->notifications->replay()` now calls the correct endpoint
+- Subscription transaction line items now include proration (`nextTransaction`, `recurringTransactionDetails`, `immediateTransaction`)
+- Transaction preview line items now include proration
 
 ## [1.5.0] - 2024-11-18
 

--- a/src/Entities/Shared/TransactionLineItemPreview.php
+++ b/src/Entities/Shared/TransactionLineItemPreview.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities\Shared;
 
 use Paddle\SDK\Entities\Product;
 use Paddle\SDK\Entities\Transaction\TransactionPreviewProduct;
+use Paddle\SDK\Entities\Transaction\TransactionProration;
 
 class TransactionLineItemPreview
 {
@@ -23,6 +24,7 @@ class TransactionLineItemPreview
         public UnitTotals $unitTotals,
         public Totals $totals,
         public Product|TransactionPreviewProduct $product,
+        public TransactionProration|null $proration,
     ) {
     }
 
@@ -37,6 +39,7 @@ class TransactionLineItemPreview
             isset($data['product']['id'])
                 ? Product::from($data['product'])
                 : TransactionPreviewProduct::from($data['product']),
+            isset($data['proration']) ? TransactionProration::from($data['proration']) : null,
         );
     }
 }

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/full_entity_with_includes.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/full_entity_with_includes.json
@@ -117,13 +117,7 @@
               "tax": "500",
               "total": "3000"
             },
-            "proration": {
-              "rate": "1",
-              "billing_period": {
-                "starts_at": "2023-12-03T16:38:53.111897Z",
-                "ends_at": "2024-01-03T16:38:53.111897Z"
-              }
-            }
+            "proration": null
           }
         ]
       },
@@ -157,6 +151,116 @@
             "earnings": "85051",
             "currency_code": "USD"
           }
+        }
+      ]
+    },
+    "recurring_transaction_details": {
+      "tax_rates_used": [
+        {
+          "tax_rate": "0.08875",
+          "totals": {
+            "subtotal": "178500",
+            "discount": "0",
+            "tax": "15841",
+            "total": "194341"
+          }
+        }
+      ],
+      "totals": {
+        "subtotal": "178500",
+        "tax": "15841",
+        "discount": "0",
+        "total": "194341",
+        "fee": null,
+        "credit": "0",
+        "credit_to_balance": "0",
+        "balance": "194341",
+        "grand_total": "194341",
+        "earnings": null,
+        "currency_code": "USD",
+        "exchange_rate": "1"
+      },
+      "line_items": [
+        {
+          "item_id": null,
+          "price_id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+          "quantity": 50,
+          "totals": {
+            "subtotal": "150000",
+            "tax": "13312",
+            "discount": "0",
+            "total": "163312"
+          },
+          "product": {
+            "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+            "name": "ChatApp Pro",
+            "type": "standard",
+            "tax_category": "standard",
+            "description": "Everything in basic, plus access to a suite of powerful tools and features designed to take your team's productivity to the next level.",
+            "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+            "custom_data": {
+              "features": {
+                "crm": true,
+                "data_retention": false,
+                "reports": true
+              },
+              "suggested_addons": [
+                "pro_01h1vjes1y163xfj1rh1tkfb65",
+                "pro_01gsz97mq9pa4fkyy0wqenepkz"
+              ],
+              "upgrade_description": "Move from Basic to Pro to take advantage of advanced reporting and a CRM that's right where you're chatting."
+            },
+            "status": "active",
+            "import_meta": null,
+            "created_at": "2023-08-16T14:38:08.3Z",
+            "updated_at": "2023-08-16T14:38:08.3Z"
+          },
+          "tax_rate": "0.08875",
+          "unit_totals": {
+            "subtotal": "3000",
+            "discount": "0",
+            "tax": "266",
+            "total": "3266"
+          },
+          "proration": {
+            "rate": "1",
+            "billing_period": {
+              "starts_at": "2024-02-08T11:02:03.946454Z",
+              "ends_at": "2024-03-08T11:02:03.946454Z"
+            }
+          }
+        },
+        {
+          "item_id": null,
+          "price_id": "pri_01gsz95g2zrkagg294kpstx54r",
+          "quantity": 1,
+          "totals": {
+            "subtotal": "28500",
+            "tax": "2529",
+            "discount": "0",
+            "total": "31029"
+          },
+          "product": {
+            "id": "pro_01gsz92krfzy3hcx5h5rtgnfwz",
+            "name": "VIP support",
+            "type": "standard",
+            "tax_category": "standard",
+            "description": "Get exclusive access to our expert team of product specialists, available to help you make the most of your ChatApp subscription.",
+            "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/SW3OevDQ92dUHSkN5a2x_icon3.png",
+            "custom_data": null,
+            "status": "active",
+            "import_meta": null,
+            "created_at": "2023-08-16T14:38:08.3Z",
+            "updated_at": "2023-08-16T14:38:08.3Z"
+          },
+          "tax_rate": "0.08875",
+          "unit_totals": {
+            "subtotal": "28500",
+            "discount": "0",
+            "tax": "2529",
+            "total": "31029"
+          },
+          "proration": null
         }
       ]
     },

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_charge_full_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_charge_full_entity.json
@@ -128,13 +128,7 @@
                         "tax": "887",
                         "total": "10887"
                     },
-                    "proration": {
-                        "rate": "1",
-                        "billing_period": {
-                            "starts_at": "2024-02-08T11:17:08.807055Z",
-                            "ends_at": "2024-03-08T11:17:08.807055Z"
-                        }
-                    }
+                    "proration": null
                 }
             ]
         },
@@ -249,13 +243,7 @@
                             "tax": "887",
                             "total": "10887"
                         },
-                        "proration": {
-                            "rate": "1",
-                            "billing_period": {
-                                "starts_at": "2024-03-08T11:17:08.807055Z",
-                                "ends_at": "2024-04-08T11:17:08.807055Z"
-                            }
-                        }
+                        "proration": null
                     }
                 ]
             },
@@ -324,7 +312,8 @@
                             "discount": "0",
                             "tax": "1766",
                             "total": "21666"
-                        }
+                        },
+                        "proration": null
                     }
                 ]
             },
@@ -378,6 +367,19 @@
                     "import_meta": null,
                     "created_at": "2023-02-23T13:55:22.538367Z",
                     "updated_at": "2023-11-09T14:07:16.051528Z"
+                },
+                "product": {
+                    "id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+                    "name": "VIP support",
+                    "type": "standard",
+                    "tax_category": "standard",
+                    "description": "Get exclusive access to our expert team of product specialists, available to help you make the most of your ChatApp subscription.",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/SW3OevDQ92dUHSkN5a2x_icon3.png",
+                    "custom_data": null,
+                    "status": "active",
+                    "import_meta": null,
+                    "created_at": "2023-08-16T14:38:08.3Z",
+                    "updated_at": "2023-08-16T14:38:08.3Z"
                 }
             },
             {
@@ -415,6 +417,19 @@
                     "import_meta": null,
                     "created_at": "2023-06-01T13:31:12.625056Z",
                     "updated_at": "2023-08-30T10:34:33.862679Z"
+                },
+                "product": {
+                    "id": "pri_01h1vjfevh5etwq3rb416a23h2",
+                    "name": "VIP support",
+                    "type": "standard",
+                    "tax_category": "standard",
+                    "description": "Get exclusive access to our expert team of product specialists, available to help you make the most of your ChatApp subscription.",
+                    "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/SW3OevDQ92dUHSkN5a2x_icon3.png",
+                    "custom_data": null,
+                    "status": "active",
+                    "import_meta": null,
+                    "created_at": "2023-08-16T14:38:08.3Z",
+                    "updated_at": "2023-08-16T14:38:08.3Z"
                 }
             }
         ],

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/preview_update_full_entity.json
@@ -128,13 +128,7 @@
             "tax": "2529",
             "total": "31029"
           },
-          "proration": {
-            "rate": "1",
-            "billing_period": {
-              "starts_at": "2024-02-08T11:02:03.946454Z",
-              "ends_at": "2024-03-08T11:02:03.946454Z"
-            }
-          }
+          "proration": null
         }
       ]
     },
@@ -249,13 +243,7 @@
               "tax": "2529",
               "total": "31029"
             },
-            "proration": {
-              "rate": "1",
-              "billing_period": {
-                "starts_at": "2024-03-08T11:02:03.946454Z",
-                "ends_at": "2024-04-08T11:02:03.946454Z"
-              }
-            }
+            "proration": null
           }
         ]
       },
@@ -372,13 +360,7 @@
               "tax": "2529",
               "total": "31027"
             },
-            "proration": {
-              "rate": "0.99993",
-              "billing_period": {
-                "starts_at": "2024-02-08T11:05:53.763Z",
-                "ends_at": "2024-03-08T11:02:03.946454Z"
-              }
-            }
+            "proration": null
           }
         ]
       },

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -650,6 +650,30 @@ class TransactionsClientTest extends TestCase
 
     /**
      * @test
+     */
+    public function get_returns_nullable_proration(): void
+    {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/full_entity')));
+        $transaction = $this->client->transactions->get('txn_01hen7bxc1p8ep4yk7n5jbzk9r');
+
+        $lineItemProration = $transaction->details->lineItems[0]->proration;
+        self::assertNotNull($lineItemProration);
+        self::assertEquals('1', $lineItemProration->rate);
+        self::assertEquals(
+            '2024-02-08T11:02:03+00:00',
+            $lineItemProration->billingPeriod->startsAt->format(DATE_RFC3339),
+        );
+        self::assertEquals(
+            '2024-03-08T11:02:03+00:00',
+            $lineItemProration->billingPeriod->endsAt->format(DATE_RFC3339),
+        );
+
+        $nullLineItemProration = $transaction->details->lineItems[1]->proration;
+        self::assertNull($nullLineItemProration);
+    }
+
+    /**
+     * @test
      *
      * @dataProvider previewOperationsProvider
      */
@@ -897,6 +921,36 @@ class TransactionsClientTest extends TestCase
         $previewProduct = $preview->details->lineItems[0]->product;
         self::assertInstanceOf(TransactionPreviewProduct::class, $previewProduct);
         self::assertNull($previewProduct->id);
+    }
+
+    /**
+     * @test
+     */
+    public function preview_returns_nullable_proration(): void
+    {
+        $this->mockClient->addResponse(new Response(200, body: self::readRawJsonFixture('response/preview_entity')));
+        $preview = $this->client->transactions->preview(
+            new PreviewTransaction(
+                items: [
+                    new TransactionItemPreviewWithPriceId('pri_01gsz8z1q1n00f12qt82y31smh', 1, true),
+                ],
+            ),
+        );
+
+        $lineItemProration = $preview->details->lineItems[0]->proration;
+        self::assertNotNull($lineItemProration);
+        self::assertEquals('1', $lineItemProration->rate);
+        self::assertEquals(
+            '2024-02-08T11:02:03+00:00',
+            $lineItemProration->billingPeriod->startsAt->format(DATE_RFC3339),
+        );
+        self::assertEquals(
+            '2024-03-08T11:02:03+00:00',
+            $lineItemProration->billingPeriod->endsAt->format(DATE_RFC3339),
+        );
+
+        $nullLineItemProration = $preview->details->lineItems[1]->proration;
+        self::assertNull($nullLineItemProration);
     }
 
     /**

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -155,7 +155,55 @@
             "tax": "486",
             "discount": "10",
             "total": "2915"
+          },
+          "proration": {
+            "rate": "1",
+            "billing_period": {
+              "starts_at": "2024-02-08T11:02:03.946454Z",
+              "ends_at": "2024-03-08T11:02:03.946454Z"
+            }
           }
+        },
+        {
+          "id": "txnitm_01hen7bxecbsbdd65s8qhyv7jw",
+          "price_id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+          "quantity": 1,
+          "totals": {
+            "subtotal": "2439",
+            "tax": "486",
+            "discount": "10",
+            "total": "2915"
+          },
+          "product": {
+            "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+            "name": "ChatApp Pro",
+            "description": "Everything in basic, plus access to a suite of powerful tools and features designed to take your team's productivity to the next level.",
+            "tax_category": "standard",
+            "image_url": "https://paddle-sandbox.s3.amazonaws.com/user/10889/2nmP8MQSret0aWeDemRw_icon1.png",
+            "custom_data": {
+              "features": {
+                "crm": true,
+                "data_retention": false,
+                "reports": true
+              },
+              "suggested_addons": [
+                "pro_01h1vjes1y163xfj1rh1tkfb65",
+                "pro_01gsz97mq9pa4fkyy0wqenepkz"
+              ],
+              "upgrade_description": "Move from Basic to Pro to take advantage of advanced reporting and a CRM that's right where you're chatting."
+            },
+            "status": "active",
+            "created_at": "2023-08-16T14:38:08.3Z",
+            "updated_at": "2023-08-16T14:38:08.3Z"
+          },
+          "tax_rate": "0.2",
+          "unit_totals": {
+            "subtotal": "2439",
+            "tax": "486",
+            "discount": "10",
+            "total": "2915"
+          },
+          "proration": null
         }
       ]
     },

--- a/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/preview_entity.json
@@ -164,6 +164,13 @@
                         "tax": "0",
                         "discount": "3000",
                         "total": "27000"
+                    },
+                    "proration": {
+                        "rate": "1",
+                        "billing_period": {
+                            "starts_at": "2024-02-08T11:02:03.946454Z",
+                            "ends_at": "2024-03-08T11:02:03.946454Z"
+                        }
                     }
                 },
                 {
@@ -192,7 +199,8 @@
                         "tax": "0",
                         "discount": "1990",
                         "total": "17910"
-                    }
+                    },
+                    "proration": null
                 }
             ]
         },


### PR DESCRIPTION
### Fixed

- Subscription transaction line items now include proration (`nextTransaction`, `recurringTransactionDetails`, `immediateTransaction`)
- Transaction preview line items now include proration