### PR TITLE
Feat: Adding support for adjustment type and VND currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [1.7.0] - 2024-12-09
+## [1.7.0] - 2024-12-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [1.7.0] - 2024-12-09
+
+### Added
+
+- Support for adjustment type, see [related changelog](https://developer.paddle.com/changelog/2024/refund-credit-full-total?utm_source=dx&utm_medium=paddle-php-sdk)
+- Added Vietnamese Dong (`VND`) as a supported currency for payments [related changelog](https://developer.paddle.com/changelog/2024/vietnamese-dong-vnd-supported-currency?utm_source=dx&utm_medium=paddle-php-sdk)
+
 ## [1.6.0] - 2024-12-05
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,7 +60,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.6.0';
+    private const SDK_VERSION = '1.7.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;

--- a/src/Entities/Adjustment.php
+++ b/src/Entities/Adjustment.php
@@ -42,7 +42,7 @@ class Adjustment implements Entity
         public array $taxRatesUsed,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface|null $updatedAt,
-        public AdjustmentType|null $type,
+        public AdjustmentType $type,
     ) {
     }
 
@@ -64,7 +64,7 @@ class Adjustment implements Entity
             taxRatesUsed: array_map(fn (array $taxRateUsed): AdjustmentTaxRatesUsed => AdjustmentTaxRatesUsed::from($taxRateUsed), $data['tax_rates_used'] ?? []),
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
-            type: isset($data['type']) ? AdjustmentType::from($data['type']) : null,
+            type: AdjustmentType::from($data['type']),
         );
     }
 }

--- a/src/Entities/Adjustment.php
+++ b/src/Entities/Adjustment.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Entities;
 
 use Paddle\SDK\Entities\Adjustment\AdjustmentItem;
 use Paddle\SDK\Entities\Adjustment\AdjustmentTaxRatesUsed;
+use Paddle\SDK\Entities\Adjustment\AdjustmentType;
 use Paddle\SDK\Entities\Shared\Action;
 use Paddle\SDK\Entities\Shared\AdjustmentStatus;
 use Paddle\SDK\Entities\Shared\AdjustmentTotals;
@@ -41,6 +42,7 @@ class Adjustment implements Entity
         public array $taxRatesUsed,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface|null $updatedAt,
+        public AdjustmentType|null $type,
     ) {
     }
 
@@ -62,6 +64,7 @@ class Adjustment implements Entity
             taxRatesUsed: array_map(fn (array $taxRateUsed): AdjustmentTaxRatesUsed => AdjustmentTaxRatesUsed::from($taxRateUsed), $data['tax_rates_used'] ?? []),
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
+            type: isset($data['type']) ? AdjustmentType::from($data['type']) : null,
         );
     }
 }

--- a/src/Entities/Adjustment/AdjustmentType.php
+++ b/src/Entities/Adjustment/AdjustmentType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Entities\Adjustment;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static AdjustmentType Full()
+ * @method static AdjustmentType Partial()
+ */
+final class AdjustmentType extends PaddleEnum
+{
+    private const Full = 'full';
+    private const Partial = 'partial';
+}

--- a/src/Entities/Shared/CurrencyCode.php
+++ b/src/Entities/Shared/CurrencyCode.php
@@ -43,6 +43,7 @@ use Paddle\SDK\PaddleEnum;
  * @method static CurrencyCode TRY()
  * @method static CurrencyCode TWD()
  * @method static CurrencyCode UAH()
+ * @method static CurrencyCode VND()
  * @method static CurrencyCode ZAR()
  */
 final class CurrencyCode extends PaddleEnum
@@ -76,5 +77,6 @@ final class CurrencyCode extends PaddleEnum
     private const TRY = 'TRY';
     private const TWD = 'TWD';
     private const UAH = 'UAH';
+    private const VND = 'VND';
     private const ZAR = 'ZAR';
 }

--- a/src/Notifications/Entities/Adjustment.php
+++ b/src/Notifications/Entities/Adjustment.php
@@ -13,6 +13,7 @@ namespace Paddle\SDK\Notifications\Entities;
 
 use Paddle\SDK\Notifications\Entities\Adjustment\AdjustmentItem;
 use Paddle\SDK\Notifications\Entities\Adjustment\AdjustmentTaxRatesUsed;
+use Paddle\SDK\Notifications\Entities\Adjustment\AdjustmentType;
 use Paddle\SDK\Notifications\Entities\Shared\Action;
 use Paddle\SDK\Notifications\Entities\Shared\AdjustmentStatus;
 use Paddle\SDK\Notifications\Entities\Shared\AdjustmentTotals;
@@ -41,6 +42,7 @@ class Adjustment implements Entity
         public array $taxRatesUsed,
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface|null $updatedAt,
+        public AdjustmentType|null $type,
     ) {
     }
 
@@ -62,6 +64,7 @@ class Adjustment implements Entity
             taxRatesUsed: array_map(fn (array $taxRateUsed): AdjustmentTaxRatesUsed => AdjustmentTaxRatesUsed::from($taxRateUsed), $data['tax_rates_used'] ?? []),
             createdAt: DateTime::from($data['created_at']),
             updatedAt: isset($data['updated_at']) ? DateTime::from($data['updated_at']) : null,
+            type: isset($data['type']) ? AdjustmentType::from($data['type']) : null,
         );
     }
 }

--- a/src/Notifications/Entities/Adjustment/AdjustmentType.php
+++ b/src/Notifications/Entities/Adjustment/AdjustmentType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Entities\Adjustment;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static AdjustmentType Full()
+ * @method static AdjustmentType Partial()
+ */
+final class AdjustmentType extends PaddleEnum
+{
+    private const Full = 'full';
+    private const Partial = 'partial';
+}

--- a/src/Notifications/Entities/Shared/CurrencyCode.php
+++ b/src/Notifications/Entities/Shared/CurrencyCode.php
@@ -43,6 +43,7 @@ use Paddle\SDK\PaddleEnum;
  * @method static CurrencyCode TRY()
  * @method static CurrencyCode TWD()
  * @method static CurrencyCode UAH()
+ * @method static CurrencyCode VND()
  * @method static CurrencyCode ZAR()
  */
 final class CurrencyCode extends PaddleEnum
@@ -76,5 +77,6 @@ final class CurrencyCode extends PaddleEnum
     private const TRY = 'TRY';
     private const TWD = 'TWD';
     private const UAH = 'UAH';
+    private const VND = 'VND';
     private const ZAR = 'ZAR';
 }

--- a/src/Resources/Adjustments/Operations/CreateAdjustment.php
+++ b/src/Resources/Adjustments/Operations/CreateAdjustment.php
@@ -4,39 +4,54 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Resources\Adjustments\Operations;
 
+use Paddle\SDK\Entities\Adjustment\AdjustmentType;
 use Paddle\SDK\Entities\Shared\Action;
+use Paddle\SDK\Exceptions\SdkExceptions\InvalidArgumentException;
+use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Resources\Adjustments\Operations\Create\AdjustmentItem;
+use Paddle\SDK\Undefined;
 
 class CreateAdjustment implements \JsonSerializable
 {
+    use FiltersUndefined;
+
     /**
      * @param array<AdjustmentItem> $items
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(
         public readonly Action $action,
-        public readonly array $items,
+        public readonly array|Undefined $items,
         public readonly string $reason,
         public readonly string $transactionId,
+        public readonly AdjustmentType|Undefined $type = new Undefined(),
     ) {
+        if ($this->type === AdjustmentType::Partial() && ($this->items instanceof Undefined || empty($this->items))) {
+            throw InvalidArgumentException::arrayIsEmpty('items');
+        }
     }
 
     public function jsonSerialize(): array
     {
         $items = [];
 
-        foreach ($this->items as $item) {
-            $items[] = [
-                'item_id' => $item->itemId,
-                'type' => $item->type->getValue(),
-                'amount' => $item->amount,
-            ];
+        if (! $this->items instanceof Undefined) {
+            foreach ($this->items as $item) {
+                $items[] = [
+                    'item_id' => $item->itemId,
+                    'type' => $item->type->getValue(),
+                    'amount' => $item->amount,
+                ];
+            }
         }
 
-        return [
+        return $this->filterUndefined([
             'action' => $this->action,
             'items' => $items,
             'reason' => $this->reason,
             'transaction_id' => $this->transactionId,
-        ];
+            'type' => $this->type,
+        ]);
     }
 }

--- a/tests/Functional/Resources/Adjustments/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Adjustments/_fixtures/response/full_entity.json
@@ -2,6 +2,7 @@
     "data": {
         "id": "adj_01h8c65c2ggq5nxswnnwv78e75",
         "action": "refund",
+        "type": "partial",
         "transaction_id": "txn_01h8bxpvx398a7zbawb77y0kp5",
         "subscription_id": "sub_01h8bxswamxysj44zt5n48njwh",
         "customer_id": "ctm_01h8441jn5pcwrfhwh78jqt8hk",

--- a/tests/Functional/Resources/Adjustments/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Adjustments/_fixtures/response/list_default.json
@@ -3,6 +3,7 @@
         {
             "id": "adj_01h8c65c2ggq5nxswnnwv78e75",
             "action": "refund",
+            "type": "partial",
             "transaction_id": "txn_01h8bxpvx398a7zbawb77y0kp5",
             "subscription_id": "sub_01h8bxswamxysj44zt5n48njwh",
             "customer_id": "ctm_01h8441jn5pcwrfhwh78jqt8hk",
@@ -55,6 +56,7 @@
         {
             "id": "adj_01h8bxezh16gm6t8rx21dx271b",
             "action": "credit",
+            "type": "partial",
             "credit_applied_to_balance": true,
             "transaction_id": "txn_01h8bx69629a16wwm9z8rjmak3",
             "subscription_id": "sub_01h8bx8fmywym11t6swgzba704",
@@ -114,6 +116,7 @@
         {
             "id": "adj_01h7jgzjqt2s8sab70e03ptkhv",
             "action": "credit",
+            "type": "partial",
             "credit_applied_to_balance": true,
             "transaction_id": "txn_01h7jgd9bkwjscj3ae15g5d3vs",
             "subscription_id": "sub_01h7ht5z5wdg9pz18jx1fagp8k",
@@ -173,6 +176,7 @@
         {
             "id": "adj_01h7jf6ptkfsc93hzc20fgf8wy",
             "action": "credit",
+            "type": "partial",
             "credit_applied_to_balance": true,
             "transaction_id": "txn_01h7je77vc1qmzxntem45ebb5q",
             "subscription_id": "sub_01h7ht5z5wdg9pz18jx1fagp8k",
@@ -232,6 +236,7 @@
         {
             "id": "adj_01h468w41ttb2j2bh8av74gwt1",
             "action": "credit",
+            "type": "partial",
             "credit_applied_to_balance": true,
             "transaction_id": "txn_01h468crc3b3fe98a5ft53recb",
             "subscription_id": "sub_01h468kv3jhs5jk330gszncsgt",

--- a/tests/Functional/Resources/Adjustments/_fixtures/response/minimal_entity.json
+++ b/tests/Functional/Resources/Adjustments/_fixtures/response/minimal_entity.json
@@ -2,6 +2,7 @@
     "data": {
         "id": "adj_01h8c65c2ggq5nxswnnwv78e75",
         "action": "refund",
+        "type": "partial",
         "transaction_id": "txn_01h8bxpvx398a7zbawb77y0kp5",
         "subscription_id": "sub_01h8bxswamxysj44zt5n48njwh",
         "customer_id": "ctm_01h8441jn5pcwrfhwh78jqt8hk",

--- a/tests/Functional/Resources/Simulations/_fixtures/request/adjustment_updated_payload.json
+++ b/tests/Functional/Resources/Simulations/_fixtures/request/adjustment_updated_payload.json
@@ -1,6 +1,7 @@
 {
   "id": "adj_01hvgf2s84dr6reszzg29zbvcm",
   "action": "refund",
+  "type": "partial",
   "transaction_id": "txn_01hvcc93znj3mpqt1tenkjb04y",
   "subscription_id": "sub_01hvccbx32q2gb40sqx7n42430",
   "customer_id": "ctm_01hrffh7gvp29kc7xahm8wddwa",

--- a/tests/Functional/Resources/Simulations/_fixtures/request/update_full.json
+++ b/tests/Functional/Resources/Simulations/_fixtures/request/update_full.json
@@ -6,6 +6,7 @@
     "payload": {
         "id": "adj_01hvgf2s84dr6reszzg29zbvcm",
         "action": "refund",
+        "type": "partial",
         "transaction_id": "txn_01hvcc93znj3mpqt1tenkjb04y",
         "subscription_id": "sub_01hvccbx32q2gb40sqx7n42430",
         "tax_rates_used": [],

--- a/tests/Functional/Resources/Simulations/_fixtures/response/full_entity_adjustment_updated.json
+++ b/tests/Functional/Resources/Simulations/_fixtures/response/full_entity_adjustment_updated.json
@@ -8,6 +8,7 @@
         "payload": {
             "id": "adj_01hvgf2s84dr6reszzg29zbvcm",
             "action": "refund",
+            "type": "partial",
             "transaction_id": "txn_01hvcc93znj3mpqt1tenkjb04y",
             "subscription_id": "sub_01hvccbx32q2gb40sqx7n42430",
             "customer_id": "ctm_01hrffh7gvp29kc7xahm8wddwa",


### PR DESCRIPTION
### Added

- Support for adjustment type, see [related changelog](https://developer.paddle.com/changelog/2024/refund-credit-full-total?utm_source=dx&utm_medium=paddle-php-sdk)
- Added Vietnamese Dong (`VND`) as a supported currency for payments [related changelog](https://developer.paddle.com/changelog/2024/vietnamese-dong-vnd-supported-currency?utm_source=dx&utm_medium=paddle-php-sdk)
