### PR TITLE
fix: Subscription discount now supports null starts_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [1.7.1] - 2024-12-13
+
+### Fixed
+
+- Subscription discount now supports null `starts_at`
+
 ## [1.7.0] - 2024-12-11
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,7 +60,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.7.0';
+    private const SDK_VERSION = '1.7.1';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;

--- a/src/Entities/Subscription/SubscriptionDiscount.php
+++ b/src/Entities/Subscription/SubscriptionDiscount.php
@@ -17,7 +17,7 @@ class SubscriptionDiscount
 {
     private function __construct(
         public string $id,
-        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface|null $startsAt,
         public \DateTimeInterface|null $endsAt,
     ) {
     }
@@ -26,7 +26,7 @@ class SubscriptionDiscount
     {
         return new self(
             $data['id'],
-            DateTime::from($data['starts_at']),
+            isset($data['starts_at']) ? DateTime::from($data['starts_at']) : null,
             isset($data['ends_at']) ? DateTime::from($data['ends_at']) : null,
         );
     }

--- a/src/Notifications/Entities/Subscription/SubscriptionDiscount.php
+++ b/src/Notifications/Entities/Subscription/SubscriptionDiscount.php
@@ -17,7 +17,7 @@ class SubscriptionDiscount
 {
     private function __construct(
         public string $id,
-        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface|null $startsAt,
         public \DateTimeInterface|null $endsAt,
     ) {
     }
@@ -26,7 +26,7 @@ class SubscriptionDiscount
     {
         return new self(
             $data['id'],
-            DateTime::from($data['starts_at']),
+            isset($data['starts_at']) ? DateTime::from($data['starts_at']) : null,
             isset($data['ends_at']) ? DateTime::from($data['ends_at']) : null,
         );
     }

--- a/tests/Functional/Resources/Subscriptions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/response/list_default.json
@@ -323,7 +323,11 @@
         "update_payment_method": null,
         "cancel": "https://sandbox-buyer-portal.paddle.com/subscriptions/sub_01hp463gxfvndqjjyqn2n7tkth/cancel"
       },
-      "discount": null,
+      "discount": {
+        "id": "dsc_01hv6scyf7qdnzcdq01t2y8dx4",
+        "starts_at": null,
+        "ends_at": null
+      },
       "import_meta": null
     },
     {
@@ -467,7 +471,11 @@
         "update_payment_method": "https://buyer-portal.paddle.com/subscriptions/sub_01hn0epy6nc46wt9hw92pp2kmt/update-payment-method",
         "cancel": "https://buyer-portal.paddle.com/subscriptions/sub_01hn0epy6nc46wt9hw92pp2kmt/cancel"
       },
-      "discount": null,
+      "discount": {
+        "id": "dsc_01hv6scyf7qdnzcdq01t2y8dx4",
+        "starts_at": "2024-04-12T10:18:47.635628Z",
+        "ends_at": "2024-05-12T10:18:47.635628Z"
+      },
       "import_meta": null
     }
   ],

--- a/tests/Unit/Entities/_fixtures/notification/entity/subscription.activated.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/subscription.activated.json
@@ -117,7 +117,11 @@
         }
     ],
     "status": "active",
-    "discount": null,
+    "discount": {
+        "id": "dsc_01hv6scyf7qdnzcdq01t2y8dx4",
+        "starts_at": "2024-04-12T10:18:47.635628Z",
+        "ends_at": "2024-05-12T10:18:47.635628Z"
+    },
     "paused_at": null,
     "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
     "created_at": "2024-04-12T10:18:48.831Z",

--- a/tests/Unit/Entities/_fixtures/notification/entity/subscription.canceled.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/subscription.canceled.json
@@ -167,7 +167,11 @@
         }
     ],
     "status": "canceled",
-    "discount": null,
+    "discount": {
+        "id": "dsc_01hv6scyf7qdnzcdq01t2y8dx4",
+        "starts_at": null,
+        "ends_at": null
+    },
     "paused_at": null,
     "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
     "created_at": "2024-04-12T10:38:00.761Z",


### PR DESCRIPTION
### Fixed

- Subscription discount now supports null `starts_at`