### PR TITLE
feat: Support transaction revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Added
+
+- Added `transactions.revise` operation to revise a transaction and added `revised_at` to `Transaction` entity, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).
+- Added support for `transaction.revised` notification, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).
+
 ## [1.8.0] - 2024-12-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 - Added `transactions.revise` operation to revise a transaction and added `revised_at` to `Transaction` entity, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).
 - Added support for `transaction.revised` notification, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).
 
+### Fixed
+- Handle known entity types for events that are not supported by the current SDK version. `UndefinedEvent` will always return an `UndefinedEntity`.
+
 ## [1.8.0] - 2024-12-19
 
 ### Added

--- a/examples/transaction_revision.php
+++ b/examples/transaction_revision.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseAddress;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseBusiness;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseCustomer;
+use Paddle\SDK\Resources\Transactions\Operations\ReviseTransaction;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$environment = Paddle\SDK\Environment::tryFrom(getenv('PADDLE_ENVIRONMENT') ?: '') ?? Paddle\SDK\Environment::SANDBOX;
+$apiKey = getenv('PADDLE_API_KEY') ?: null;
+$transactionId = getenv('PADDLE_TRANSACTION_ID') ?: null;
+
+if (is_null($apiKey)) {
+    echo "You must provide the PADDLE_API_KEY in the environment:\n";
+    echo "PADDLE_API_KEY=your-key php examples/basic_usage.php\n";
+    exit(1);
+}
+
+$paddle = new Paddle\SDK\Client($apiKey, options: new Paddle\SDK\Options($environment));
+
+// ┌───
+// │ Revise Transaction │
+// └────────────────────┘
+try {
+    $transaction = $paddle->transactions->revise(
+        $transactionId,
+        new ReviseTransaction(
+            address: new TransactionReviseAddress(
+                firstLine: '123 Some Street',
+                secondLine: null,
+            ),
+            business: new TransactionReviseBusiness(
+                name: 'Some Business',
+                taxIdentifier: '555952383',
+            ),
+            customer: new TransactionReviseCustomer(
+                name: 'Some Name',
+            ),
+        ),
+    );
+} catch (ApiError|MalformedResponse $e) {
+    var_dump($e);
+    exit;
+}
+
+echo sprintf("Transaction ID: %s\n", $transaction->id);
+echo sprintf(" - Revised At: %s\n", $transaction->revisedAt->format(DATE_RFC3339_EXTENDED));

--- a/src/Entities/Event.php
+++ b/src/Entities/Event.php
@@ -7,6 +7,7 @@ namespace Paddle\SDK\Entities;
 use Paddle\SDK\Entities\Event\EventTypeName;
 use Paddle\SDK\Notifications\Entities\Entity as NotificationEntity;
 use Paddle\SDK\Notifications\Entities\EntityFactory;
+use Paddle\SDK\Notifications\Entities\UndefinedEntity;
 use Paddle\SDK\Notifications\Events\UndefinedEvent;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -33,11 +34,16 @@ abstract class Event implements Entity
             $event = UndefinedEvent::class;
         }
 
+        // Create an undefined entity for undefined events.
+        $entity = $event === UndefinedEvent::class
+            ? UndefinedEntity::from($data['data'])
+            : EntityFactory::create($data['event_type'], $data['data']);
+
         return $event::fromEvent(
             $data['event_id'],
             EventTypeName::from($data['event_type']),
             DateTime::from($data['occurred_at']),
-            EntityFactory::create($data['event_type'], $data['data']),
+            $entity,
             $data['notification_id'] ?? null,
         );
     }

--- a/src/Entities/Event/EventTypeName.php
+++ b/src/Entities/Event/EventTypeName.php
@@ -52,6 +52,7 @@ use Paddle\SDK\PaddleEnum;
  * @method static EventTypeName TransactionPastDue()
  * @method static EventTypeName TransactionPaymentFailed()
  * @method static EventTypeName TransactionReady()
+ * @method static EventTypeName TransactionRevised()
  * @method static EventTypeName TransactionUpdated()
  * @method static EventTypeName ReportCreated()
  * @method static EventTypeName ReportUpdated()
@@ -103,6 +104,7 @@ final class EventTypeName extends PaddleEnum
     private const TransactionPastDue = 'transaction.past_due';
     private const TransactionPaymentFailed = 'transaction.payment_failed';
     private const TransactionReady = 'transaction.ready';
+    private const TransactionRevised = 'transaction.revised';
     private const TransactionUpdated = 'transaction.updated';
     private const ReportCreated = 'report.created';
     private const ReportUpdated = 'report.updated';

--- a/src/Entities/Transaction.php
+++ b/src/Entities/Transaction.php
@@ -63,6 +63,7 @@ class Transaction implements Entity
         public Customer|null $customer,
         public Discount|null $discount,
         public array $availablePaymentMethods,
+        public \DateTimeInterface|null $revisedAt,
     ) {
     }
 
@@ -98,6 +99,7 @@ class Transaction implements Entity
             customer: isset($data['customer']) ? Customer::from($data['customer']) : null,
             discount: isset($data['discount']) ? Discount::from($data['discount']) : null,
             availablePaymentMethods: array_map(fn (string $item): AvailablePaymentMethods => AvailablePaymentMethods::from($item), $data['available_payment_methods'] ?? []),
+            revisedAt: isset($data['revised_at']) ? DateTime::from($data['revised_at']) : null,
         );
     }
 }

--- a/src/Notifications/Entities/Transaction.php
+++ b/src/Notifications/Entities/Transaction.php
@@ -52,6 +52,7 @@ class Transaction implements Entity
         public \DateTimeInterface $createdAt,
         public \DateTimeInterface $updatedAt,
         public \DateTimeInterface|null $billedAt,
+        public \DateTimeInterface|null $revisedAt,
     ) {
     }
 
@@ -80,6 +81,7 @@ class Transaction implements Entity
             createdAt: DateTime::from($data['created_at']),
             updatedAt: DateTime::from($data['updated_at']),
             billedAt: isset($data['billed_at']) ? DateTime::from($data['billed_at']) : null,
+            revisedAt: isset($data['revised_at']) ? DateTime::from($data['revised_at']) : null,
         );
     }
 }

--- a/src/Notifications/Events/TransactionRevised.php
+++ b/src/Notifications/Events/TransactionRevised.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Notifications\Events;
+
+use Paddle\SDK\Entities\Event;
+use Paddle\SDK\Entities\Event\EventTypeName;
+use Paddle\SDK\Notifications\Entities\Entity;
+use Paddle\SDK\Notifications\Entities\Transaction;
+
+final class TransactionRevised extends Event
+{
+    private function __construct(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        public readonly Transaction $transaction,
+        string|null $notificationId,
+    ) {
+        parent::__construct($eventId, $eventType, $occurredAt, $transaction, $notificationId);
+    }
+
+    /**
+     * @param Transaction $data
+     */
+    public static function fromEvent(
+        string $eventId,
+        EventTypeName $eventType,
+        \DateTimeInterface $occurredAt,
+        Entity $data,
+        string|null $notificationId = null,
+    ): static {
+        return new self($eventId, $eventType, $occurredAt, $data, $notificationId);
+    }
+}

--- a/src/Resources/Transactions/Operations/Revise/TransactionReviseAddress.php
+++ b/src/Resources/Transactions/Operations/Revise/TransactionReviseAddress.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Revise;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionReviseAddress implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public readonly string|Undefined $firstLine = new Undefined(),
+        public readonly string|Undefined|null $secondLine = new Undefined(),
+        public readonly string|Undefined $city = new Undefined(),
+        public readonly string|Undefined $region = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'first_line' => $this->firstLine,
+            'second_line' => $this->secondLine,
+            'city' => $this->city,
+            'region' => $this->region,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/Revise/TransactionReviseBusiness.php
+++ b/src/Resources/Transactions/Operations/Revise/TransactionReviseBusiness.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Revise;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionReviseBusiness implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public readonly string|Undefined $name = new Undefined(),
+        public readonly string|Undefined $taxIdentifier = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'name' => $this->name,
+            'tax_identifier' => $this->taxIdentifier,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/Revise/TransactionReviseCustomer.php
+++ b/src/Resources/Transactions/Operations/Revise/TransactionReviseCustomer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Revise;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionReviseCustomer implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public readonly string|Undefined $name = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'name' => $this->name,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/ReviseTransaction.php
+++ b/src/Resources/Transactions/Operations/ReviseTransaction.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations;
+
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseAddress;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseBusiness;
+use Paddle\SDK\Resources\Transactions\Operations\Revise\TransactionReviseCustomer;
+use Paddle\SDK\Undefined;
+
+class ReviseTransaction implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    public function __construct(
+        public readonly TransactionReviseAddress|Undefined|null $address = new Undefined(),
+        public readonly TransactionReviseBusiness|Undefined|null $business = new Undefined(),
+        public readonly TransactionReviseCustomer|Undefined|null $customer = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'address' => $this->address,
+            'customer' => $this->customer,
+            'business' => $this->business,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/TransactionsClient.php
+++ b/src/Resources/Transactions/TransactionsClient.php
@@ -25,6 +25,7 @@ use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\ListTransactions;
 use Paddle\SDK\Resources\Transactions\Operations\PreviewTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\ReviseTransaction;
 use Paddle\SDK\Resources\Transactions\Operations\UpdateTransaction;
 use Paddle\SDK\ResponseParser;
 
@@ -136,5 +137,19 @@ class TransactionsClient
         );
 
         return TransactionData::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError                     On a generic API error
+     * @throws ApiError\TransactionApiError On a transaction specific API error
+     * @throws MalformedResponse            If the API response was not parsable
+     */
+    public function revise(string $id, ReviseTransaction $operation): Transaction
+    {
+        $parser = new ResponseParser(
+            $this->client->postRaw("/transactions/{$id}/revise", $operation),
+        );
+
+        return Transaction::from($parser->getData());
     }
 }

--- a/tests/Functional/Resources/EventTypes/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/EventTypes/_fixtures/response/list_default.json
@@ -57,6 +57,14 @@
             ]
         },
         {
+            "name": "transaction.revised",
+            "description": "Occurs when a transaction is revised.",
+            "group": "Transaction",
+            "available_versions": [
+                1
+            ]
+        },
+        {
             "name": "transaction.updated",
             "description": "Occurs when a transaction is updated.",
             "group": "Transaction",

--- a/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Notifications/_fixtures/response/list_default.json
@@ -474,6 +474,343 @@
             "retry_at": null,
             "times_attempted": 1,
             "notification_setting_id": "ntfset_01h7zcdzf04a7wvyja9k9p1n3p"
+        },
+        {
+            "id": "ntf_01hv8x2azy7scaan4s0eb0273x",
+            "type": "transaction.revised",
+            "status": "delivered",
+            "payload": {
+                "data": {
+                    "id": "txn_01hv8wptq8987qeep44cyrewp9",
+                    "items": [
+                        {
+                            "price": {
+                                "id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+                                "name": "Monthly (per seat)",
+                                "type": "standard",
+                                "status": "active",
+                                "quantity": {
+                                    "maximum": 999,
+                                    "minimum": 1
+                                },
+                                "tax_mode": "account_setting",
+                                "created_at": "2023-02-23T13:55:22.538367Z",
+                                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                                "unit_price": {
+                                    "amount": "3000",
+                                    "currency_code": "USD"
+                                },
+                                "updated_at": "2024-04-11T13:54:52.254748Z",
+                                "custom_data": null,
+                                "description": "Monthly",
+                                "trial_period": null,
+                                "billing_cycle": {
+                                    "interval": "month",
+                                    "frequency": 1
+                                },
+                                "unit_price_overrides": [],
+                                "import_meta": null
+                            },
+                            "quantity": 10,
+                            "proration": null
+                        },
+                        {
+                            "price": {
+                                "id": "pri_01h1vjfevh5etwq3rb416a23h2",
+                                "name": "Monthly (recurring addon)",
+                                "type": "standard",
+                                "status": "active",
+                                "quantity": {
+                                    "maximum": 100,
+                                    "minimum": 1
+                                },
+                                "tax_mode": "account_setting",
+                                "created_at": "2023-06-01T13:31:12.625056Z",
+                                "product_id": "pro_01h1vjes1y163xfj1rh1tkfb65",
+                                "unit_price": {
+                                    "amount": "10000",
+                                    "currency_code": "USD"
+                                },
+                                "updated_at": "2024-04-09T07:23:00.907834Z",
+                                "custom_data": null,
+                                "description": "Monthly",
+                                "trial_period": null,
+                                "billing_cycle": {
+                                    "interval": "month",
+                                    "frequency": 1
+                                },
+                                "unit_price_overrides": [],
+                                "import_meta": null
+                            },
+                            "quantity": 1,
+                            "proration": null
+                        },
+                        {
+                            "price": {
+                                "id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                                "name": "One-time addon",
+                                "type": "standard",
+                                "status": "active",
+                                "quantity": {
+                                    "maximum": 1,
+                                    "minimum": 1
+                                },
+                                "tax_mode": "account_setting",
+                                "created_at": "2023-02-23T14:01:28.391712Z",
+                                "product_id": "pro_01gsz97mq9pa4fkyy0wqenepkz",
+                                "unit_price": {
+                                    "amount": "19900",
+                                    "currency_code": "USD"
+                                },
+                                "updated_at": "2024-04-09T07:23:10.921392Z",
+                                "custom_data": null,
+                                "description": "One-time addon",
+                                "trial_period": null,
+                                "billing_cycle": null,
+                                "unit_price_overrides": [],
+                                "import_meta": null
+                            },
+                            "quantity": 1,
+                            "proration": null
+                        }
+                    ],
+                    "origin": "web",
+                    "status": "completed",
+                    "details": {
+                        "totals": {
+                            "fee": "3311",
+                            "tax": "5315",
+                            "total": "65215",
+                            "credit": "0",
+                            "balance": "0",
+                            "discount": "0",
+                            "earnings": "56589",
+                            "subtotal": "59900",
+                            "grand_total": "65215",
+                            "currency_code": "USD",
+                            "credit_to_balance": "0"
+                        },
+                        "line_items": [
+                            {
+                                "id": "txnitm_01hv8wt98jahpbm1t1tzr06z6n",
+                                "totals": {
+                                    "tax": "2662",
+                                    "total": "32662",
+                                    "discount": "0",
+                                    "subtotal": "30000"
+                                },
+                                "product": {
+                                    "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                                    "name": "AeroEdit Pro",
+                                    "type": "standard",
+                                    "status": "active",
+                                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/bT1XUOJAQhOUxGs83cbk_pro.png",
+                                    "created_at": "2023-02-23T12:43:46.605Z",
+                                    "updated_at": "2024-04-05T15:53:44.687Z",
+                                    "custom_data": {
+                                        "features": {
+                                            "sso": false,
+                                            "route_planning": true,
+                                            "payment_by_invoice": false,
+                                            "aircraft_performance": true,
+                                            "compliance_monitoring": true,
+                                            "flight_log_management": true
+                                        },
+                                        "suggested_addons": [
+                                            "pro_01h1vjes1y163xfj1rh1tkfb65",
+                                            "pro_01gsz97mq9pa4fkyy0wqenepkz"
+                                        ],
+                                        "upgrade_description": "Move from Basic to Pro to take advantage of aircraft performance, advanced route planning, and compliance monitoring."
+                                    },
+                                    "description": "Designed for professional pilots, including all features plus in Basic plus compliance monitoring, route optimization, and third-party integrations.",
+                                    "tax_category": "standard",
+                                    "import_meta": null
+                                },
+                                "price_id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+                                "quantity": 10,
+                                "tax_rate": "0.08875",
+                                "unit_totals": {
+                                    "tax": "266",
+                                    "total": "3266",
+                                    "discount": "0",
+                                    "subtotal": "3000"
+                                }
+                            },
+                            {
+                                "id": "txnitm_01hv8wt98jahpbm1t1v1sd067y",
+                                "totals": {
+                                    "tax": "887",
+                                    "total": "10887",
+                                    "discount": "0",
+                                    "subtotal": "10000"
+                                },
+                                "product": {
+                                    "id": "pro_01h1vjes1y163xfj1rh1tkfb65",
+                                    "name": "Analytics addon",
+                                    "type": "standard",
+                                    "status": "active",
+                                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/97dRpA6SXzcE6ekK9CAr_analytics.png",
+                                    "created_at": "2023-06-01T13:30:50.302Z",
+                                    "updated_at": "2024-04-05T15:47:17.163Z",
+                                    "custom_data": null,
+                                    "description": "Unlock advanced insights into your flight data with enhanced analytics and reporting features. Includes customizable reporting templates and trend analysis across flights.",
+                                    "tax_category": "standard",
+                                    "import_meta": null
+                                },
+                                "price_id": "pri_01h1vjfevh5etwq3rb416a23h2",
+                                "quantity": 1,
+                                "tax_rate": "0.08875",
+                                "unit_totals": {
+                                    "tax": "887",
+                                    "total": "10887",
+                                    "discount": "0",
+                                    "subtotal": "10000"
+                                }
+                            },
+                            {
+                                "id": "txnitm_01hv8wt98jahpbm1t1v67vqnb6",
+                                "totals": {
+                                    "tax": "1766",
+                                    "total": "21666",
+                                    "discount": "0",
+                                    "subtotal": "19900"
+                                },
+                                "product": {
+                                    "id": "pro_01gsz97mq9pa4fkyy0wqenepkz",
+                                    "name": "Custom domains",
+                                    "type": "standard",
+                                    "status": "active",
+                                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/XIG7UXoJQHmlIAiKcnkA_custom-domains.png",
+                                    "created_at": "2023-02-23T14:01:02.441Z",
+                                    "updated_at": "2024-04-05T15:43:28.971Z",
+                                    "custom_data": null,
+                                    "description": "Make AeroEdit truly your own with custom domains. Custom domains reinforce your brand identity and make it easy for your team to access your account.",
+                                    "tax_category": "standard",
+                                    "import_meta": null
+                                },
+                                "price_id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                                "quantity": 1,
+                                "tax_rate": "0.08875",
+                                "unit_totals": {
+                                    "tax": "1766",
+                                    "total": "21666",
+                                    "discount": "0",
+                                    "subtotal": "19900"
+                                }
+                            }
+                        ],
+                        "payout_totals": {
+                            "fee": "3311",
+                            "tax": "5315",
+                            "total": "65215",
+                            "credit": "0",
+                            "balance": "0",
+                            "discount": "0",
+                            "earnings": "56589",
+                            "subtotal": "59900",
+                            "grand_total": "65215",
+                            "currency_code": "USD",
+                            "credit_to_balance": "0"
+                        },
+                        "tax_rates_used": [
+                            {
+                                "totals": {
+                                    "tax": "5315",
+                                    "total": "65215",
+                                    "discount": "0",
+                                    "subtotal": "59900"
+                                },
+                                "tax_rate": "0.08875"
+                            }
+                        ],
+                        "adjusted_totals": {
+                            "fee": "3311",
+                            "tax": "5315",
+                            "total": "65215",
+                            "earnings": "56589",
+                            "subtotal": "59900",
+                            "grand_total": "65215",
+                            "currency_code": "USD"
+                        }
+                    },
+                    "checkout": {
+                        "url": "https://aeroedit.com/pay?_ptxn=txn_01hv8wptq8987qeep44cyrewp9"
+                    },
+                    "payments": [
+                        {
+                            "amount": "65215",
+                            "status": "captured",
+                            "created_at": "2024-04-12T10:18:33.579142Z",
+                            "error_code": null,
+                            "captured_at": "2024-04-12T10:18:47.635628Z",
+                            "method_details": {
+                                "card": {
+                                    "type": "visa",
+                                    "last4": "3184",
+                                    "expiry_year": 2025,
+                                    "expiry_month": 1,
+                                    "cardholder_name": "Michael McGovern"
+                                },
+                                "type": "card"
+                            },
+                            "payment_method_id": "paymtd_01hv8x1tpjfnttxddw73xnqx6s",
+                            "payment_attempt_id": "937640dd-e3dc-40df-a16c-bb75aafd8f71",
+                            "stored_payment_method_id": "281ff2ca-8550-42b9-bf39-15948e7de62d"
+                        },
+                        {
+                            "amount": "65215",
+                            "status": "error",
+                            "created_at": "2024-04-12T10:15:57.888183Z",
+                            "error_code": "declined",
+                            "captured_at": null,
+                            "method_details": {
+                                "card": {
+                                    "type": "visa",
+                                    "last4": "0002",
+                                    "expiry_year": 2025,
+                                    "expiry_month": 1,
+                                    "cardholder_name": "Michael McGovern"
+                                },
+                                "type": "card"
+                            },
+                            "payment_method_id": "paymtd_01hv8wx2mka7dfsqjjsxh1ne7z",
+                            "payment_attempt_id": "8f72cfa6-26b4-4a57-91dc-8f2708f7822d",
+                            "stored_payment_method_id": "a78ece50-356f-4e0c-b72d-ad5368b0a0d9"
+                        }
+                    ],
+                    "billed_at": "2024-04-12T10:18:48.294633Z",
+                    "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+                    "created_at": "2024-04-12T10:12:33.2014Z",
+                    "invoice_id": "inv_01hv8x29nsh54c2pgt0hnq0zkx",
+                    "updated_at": "2024-04-12T10:18:49.738971238Z",
+                    "revised_at": "2024-04-12T10:18:50.738972238Z",
+                    "business_id": null,
+                    "custom_data": null,
+                    "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+                    "discount_id": null,
+                    "currency_code": "USD",
+                    "billing_period": {
+                        "ends_at": "2024-05-12T10:18:47.635628Z",
+                        "starts_at": "2024-04-12T10:18:47.635628Z"
+                    },
+                    "invoice_number": "325-10566",
+                    "billing_details": null,
+                    "collection_mode": "automatic",
+                    "subscription_id": "sub_01hv8x29kz0t586xy6zn1a62ny"
+                },
+                "event_id": "evt_01hv8x2axb33yr5y238zfwcn5p",
+                "event_type": "transaction.revised",
+                "occurred_at": "2024-04-12T10:18:50.155553Z",
+                "notification_id": "ntf_01hv8x2azy7scaan4s0eb0273x"
+            },
+            "occurred_at": "2023-08-18T10:46:18.792661Z",
+            "delivered_at": "2023-08-18T10:46:19.396422Z",
+            "replayed_at": null,
+            "origin": "event",
+            "last_attempt_at": "2023-08-18T10:46:18.887423Z",
+            "retry_at": null,
+            "times_attempted": 1,
+            "notification_setting_id": "ntfset_01h7zcdzf04a7wvyja9k9p1n3p"
         }
     ],
     "meta": {

--- a/tests/Functional/Resources/SimulationTypes/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/SimulationTypes/_fixtures/response/list_default.json
@@ -507,6 +507,16 @@
             ]
         },
         {
+            "name": "transaction.revised",
+            "label": "transaction.revised",
+            "description": "Occurs when a transaction is revised.",
+            "group": "Transaction",
+            "type": "single_event",
+            "events": [
+                "transaction.revised"
+            ]
+        },
+        {
             "name": "transaction.updated",
             "label": "transaction.updated",
             "description": "Occurs when a transaction is updated.",

--- a/tests/Functional/Resources/Transactions/_fixtures/request/revise_basic.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/revise_basic.json
@@ -1,0 +1,11 @@
+{
+    "customer": {
+        "name": "Sam Miller"
+    },
+    "business": {
+        "name": "Some Business"
+    },
+    "address": {
+        "first_line": "3811 Ditmars Blvd"
+    }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/revise_customer.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/revise_customer.json
@@ -1,0 +1,5 @@
+{
+    "customer": {
+        "name": "Sam Miller"
+    }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/revise_full.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/revise_full.json
@@ -1,0 +1,15 @@
+{
+    "customer": {
+        "name": "Sam Miller"
+    },
+    "business": {
+        "name": "Some Business",
+        "tax_identifier": "AB0123456789"
+    },
+    "address": {
+        "first_line": "3811 Ditmars Blvd",
+        "second_line": null,
+        "city": "Some City",
+        "region": "Some Region"
+    }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity.json
@@ -29,6 +29,7 @@
     "created_at": "2023-11-07T15:45:39.297512Z",
     "updated_at": "2023-11-07T15:45:45.086499Z",
     "billed_at": "2023-11-07T15:45:39.201442Z",
+    "revised_at": null,
     "items": [
       {
         "price": {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/full_entity_with_includes.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/full_entity_with_includes.json
@@ -29,6 +29,7 @@
     "created_at": "2023-11-07T15:45:39.297512Z",
     "updated_at": "2023-11-07T15:45:45.086499Z",
     "billed_at": "2023-11-07T15:45:39.201442Z",
+    "revised_at": null,
     "items": [
       {
         "price": {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -30,6 +30,7 @@
       "created_at": "2023-08-21T08:40:00.766226Z",
       "updated_at": "2023-08-21T08:46:37.414122Z",
       "billed_at": null,
+      "revised_at": null,
       "items": [
         {
           "price": {
@@ -264,6 +265,7 @@
       "created_at": "2023-08-21T07:49:16.634436Z",
       "updated_at": "2023-08-21T07:49:16.634436Z",
       "billed_at": null,
+      "revised_at": null,
       "items": [
         {
           "price": {
@@ -518,6 +520,7 @@
       "created_at": "2023-08-21T07:48:01.560677Z",
       "updated_at": "2023-08-21T08:54:11.273239Z",
       "billed_at": null,
+      "revised_at": null,
       "items": [
         {
           "price": {
@@ -775,6 +778,7 @@
       "created_at": "2023-08-18T21:13:07.033262Z",
       "updated_at": "2023-08-18T21:13:14.83528Z",
       "billed_at": "2023-08-18T21:13:06.616004Z",
+      "revised_at": null,
       "items": [
         {
           "price": {
@@ -1023,6 +1027,7 @@
       "created_at": "2023-08-16T14:46:05.86701Z",
       "updated_at": "2023-08-19T14:47:05.97537Z",
       "billed_at": "2023-08-16T14:46:05.489912Z",
+      "revised_at": null,
       "items": [
         {
           "price": {
@@ -1153,6 +1158,7 @@
       "created_at": "2023-07-26T15:35:06.134251Z",
       "updated_at": "2023-07-26T15:35:11.182344Z",
       "billed_at": "2023-07-26T15:35:05.739403Z",
+      "revised_at": "2023-07-26T15:35:06.739403Z",
       "items": [
         {
           "price": {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
@@ -30,6 +30,7 @@
             "created_at": "2023-08-21T08:40:00.766226Z",
             "updated_at": "2023-08-21T08:46:37.414122Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -262,6 +263,7 @@
             "created_at": "2023-08-21T07:49:16.634436Z",
             "updated_at": "2023-08-21T07:49:16.634436Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -510,6 +512,7 @@
             "created_at": "2023-08-21T07:48:01.560677Z",
             "updated_at": "2023-08-21T08:54:11.273239Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -761,6 +764,7 @@
             "created_at": "2023-08-18T21:13:07.033262Z",
             "updated_at": "2023-08-18T21:13:14.83528Z",
             "billed_at": "2023-08-18T21:13:06.616004Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -989,6 +993,7 @@
             "created_at": "2023-08-16T14:46:05.86701Z",
             "updated_at": "2023-08-19T14:47:05.97537Z",
             "billed_at": "2023-08-16T14:46:05.489912Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -1119,6 +1124,7 @@
             "created_at": "2023-07-26T15:35:06.134251Z",
             "updated_at": "2023-07-26T15:35:11.182344Z",
             "billed_at": "2023-07-26T15:35:05.739403Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
@@ -30,6 +30,7 @@
             "created_at": "2023-08-21T08:40:00.766226Z",
             "updated_at": "2023-08-21T08:46:37.414122Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -262,6 +263,7 @@
             "created_at": "2023-08-21T07:49:16.634436Z",
             "updated_at": "2023-08-21T07:49:16.634436Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -510,6 +512,7 @@
             "created_at": "2023-08-21T07:48:01.560677Z",
             "updated_at": "2023-08-21T08:54:11.273239Z",
             "billed_at": null,
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -761,6 +764,7 @@
             "created_at": "2023-08-18T21:13:07.033262Z",
             "updated_at": "2023-08-18T21:13:14.83528Z",
             "billed_at": "2023-08-18T21:13:06.616004Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -989,6 +993,7 @@
             "created_at": "2023-08-16T14:46:05.86701Z",
             "updated_at": "2023-08-19T14:47:05.97537Z",
             "billed_at": "2023-08-16T14:46:05.489912Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {
@@ -1119,6 +1124,7 @@
             "created_at": "2023-07-26T15:35:06.134251Z",
             "updated_at": "2023-07-26T15:35:11.182344Z",
             "billed_at": "2023-07-26T15:35:05.739403Z",
+            "revised_at": null,
             "items": [
                 {
                     "price": {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/minimal_entity.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/minimal_entity.json
@@ -18,6 +18,7 @@
     "created_at": "2023-11-07T10:51:19.601401071Z",
     "updated_at": "2023-11-07T10:51:19.601401071Z",
     "billed_at": null,
+    "revised_at": null,
     "items": [
       {
         "price": {

--- a/tests/Unit/Entities/EventTest.php
+++ b/tests/Unit/Entities/EventTest.php
@@ -10,6 +10,7 @@ use Paddle\SDK\Notifications\Entities\Entity;
 use Paddle\SDK\Notifications\Entities\PaymentMethod;
 use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodDeletionReason;
 use Paddle\SDK\Notifications\Entities\Shared\SavedPaymentMethodOrigin;
+use Paddle\SDK\Notifications\Entities\UndefinedEntity;
 use Paddle\SDK\Notifications\Events\PaymentMethodDeleted;
 use Paddle\SDK\Notifications\Events\PaymentMethodSaved;
 use Paddle\SDK\Notifications\Events\SubscriptionActivated;
@@ -324,6 +325,12 @@ class EventTest extends TestCase
                 \Paddle\SDK\Notifications\Entities\Transaction::class,
             ],
             [
+                'transaction.revised',
+                'transaction',
+                \Paddle\SDK\Notifications\Events\TransactionRevised::class,
+                \Paddle\SDK\Notifications\Entities\Transaction::class,
+            ],
+            [
                 'transaction.updated',
                 'transaction',
                 \Paddle\SDK\Notifications\Events\TransactionUpdated::class,
@@ -372,6 +379,29 @@ class EventTest extends TestCase
 
         self::assertInstanceOf(Event::class, $event);
         self::assertInstanceOf(Entity::class, $event->data);
+        self::assertInstanceOf(UndefinedEntity::class, $event->data);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_event_for_undefined_event_with_known_entity(): void
+    {
+        $event = Event::from([
+            'event_id' => 'evt_01h8bzakzx3hm2fmen703n5q45',
+            'event_type' => 'transaction.unknown_event',
+            'occurred_at' => '2023-08-21T11:57:47.390028Z',
+            'notification_id' => 'ntf_01h8bzam1z32agrxjwhjgqk8w6',
+            'data' => [
+                'some' => 'data',
+            ],
+        ]);
+
+        self::assertSame('ntf_01h8bzam1z32agrxjwhjgqk8w6', $event->notificationId);
+
+        self::assertInstanceOf(Event::class, $event);
+        self::assertInstanceOf(Entity::class, $event->data);
+        self::assertInstanceOf(UndefinedEntity::class, $event->data);
     }
 
     /**

--- a/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
@@ -1,0 +1,318 @@
+{
+    "id": "txn_01hv8wptq8987qeep44cyrewp9",
+    "items": [
+        {
+            "price": {
+                "id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+                "name": "Monthly (per seat)",
+                "type": "standard",
+                "status": "active",
+                "quantity": {
+                    "maximum": 999,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "created_at": "2023-02-23T13:55:22.538367Z",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "unit_price": {
+                    "amount": "3000",
+                    "currency_code": "USD"
+                },
+                "updated_at": "2024-04-11T13:54:52.254748Z",
+                "custom_data": null,
+                "description": "Monthly",
+                "trial_period": null,
+                "billing_cycle": {
+                    "interval": "month",
+                    "frequency": 1
+                },
+                "unit_price_overrides": [],
+                "import_meta": null
+            },
+            "quantity": 10,
+            "proration": null
+        },
+        {
+            "price": {
+                "id": "pri_01h1vjfevh5etwq3rb416a23h2",
+                "name": "Monthly (recurring addon)",
+                "type": "standard",
+                "status": "active",
+                "quantity": {
+                    "maximum": 100,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "created_at": "2023-06-01T13:31:12.625056Z",
+                "product_id": "pro_01h1vjes1y163xfj1rh1tkfb65",
+                "unit_price": {
+                    "amount": "10000",
+                    "currency_code": "USD"
+                },
+                "updated_at": "2024-04-09T07:23:00.907834Z",
+                "custom_data": null,
+                "description": "Monthly",
+                "trial_period": null,
+                "billing_cycle": {
+                    "interval": "month",
+                    "frequency": 1
+                },
+                "unit_price_overrides": [],
+                "import_meta": null
+            },
+            "quantity": 1,
+            "proration": null
+        },
+        {
+            "price": {
+                "id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                "name": "One-time addon",
+                "type": "standard",
+                "status": "active",
+                "quantity": {
+                    "maximum": 1,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "created_at": "2023-02-23T14:01:28.391712Z",
+                "product_id": "pro_01gsz97mq9pa4fkyy0wqenepkz",
+                "unit_price": {
+                    "amount": "19900",
+                    "currency_code": "USD"
+                },
+                "updated_at": "2024-04-09T07:23:10.921392Z",
+                "custom_data": null,
+                "description": "One-time addon",
+                "trial_period": null,
+                "billing_cycle": null,
+                "unit_price_overrides": [],
+                "import_meta": null
+            },
+            "quantity": 1,
+            "proration": null
+        }
+    ],
+    "origin": "web",
+    "status": "completed",
+    "details": {
+        "totals": {
+            "fee": "3311",
+            "tax": "5315",
+            "total": "65215",
+            "credit": "0",
+            "balance": "0",
+            "discount": "0",
+            "earnings": "56589",
+            "subtotal": "59900",
+            "grand_total": "65215",
+            "currency_code": "USD",
+            "credit_to_balance": "0"
+        },
+        "line_items": [
+            {
+                "id": "txnitm_01hv8wt98jahpbm1t1tzr06z6n",
+                "totals": {
+                    "tax": "2662",
+                    "total": "32662",
+                    "discount": "0",
+                    "subtotal": "30000"
+                },
+                "product": {
+                    "id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                    "name": "AeroEdit Pro",
+                    "type": "standard",
+                    "status": "active",
+                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/bT1XUOJAQhOUxGs83cbk_pro.png",
+                    "created_at": "2023-02-23T12:43:46.605Z",
+                    "updated_at": "2024-04-05T15:53:44.687Z",
+                    "custom_data": {
+                        "features": {
+                            "sso": false,
+                            "route_planning": true,
+                            "payment_by_invoice": false,
+                            "aircraft_performance": true,
+                            "compliance_monitoring": true,
+                            "flight_log_management": true
+                        },
+                        "suggested_addons": [
+                            "pro_01h1vjes1y163xfj1rh1tkfb65",
+                            "pro_01gsz97mq9pa4fkyy0wqenepkz"
+                        ],
+                        "upgrade_description": "Move from Basic to Pro to take advantage of aircraft performance, advanced route planning, and compliance monitoring."
+                    },
+                    "description": "Designed for professional pilots, including all features plus in Basic plus compliance monitoring, route optimization, and third-party integrations.",
+                    "tax_category": "standard",
+                    "import_meta": null
+                },
+                "price_id": "pri_01gsz8x8sawmvhz1pv30nge1ke",
+                "quantity": 10,
+                "tax_rate": "0.08875",
+                "unit_totals": {
+                    "tax": "266",
+                    "total": "3266",
+                    "discount": "0",
+                    "subtotal": "3000"
+                }
+            },
+            {
+                "id": "txnitm_01hv8wt98jahpbm1t1v1sd067y",
+                "totals": {
+                    "tax": "887",
+                    "total": "10887",
+                    "discount": "0",
+                    "subtotal": "10000"
+                },
+                "product": {
+                    "id": "pro_01h1vjes1y163xfj1rh1tkfb65",
+                    "name": "Analytics addon",
+                    "type": "standard",
+                    "status": "active",
+                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/97dRpA6SXzcE6ekK9CAr_analytics.png",
+                    "created_at": "2023-06-01T13:30:50.302Z",
+                    "updated_at": "2024-04-05T15:47:17.163Z",
+                    "custom_data": null,
+                    "description": "Unlock advanced insights into your flight data with enhanced analytics and reporting features. Includes customizable reporting templates and trend analysis across flights.",
+                    "tax_category": "standard",
+                    "import_meta": null
+                },
+                "price_id": "pri_01h1vjfevh5etwq3rb416a23h2",
+                "quantity": 1,
+                "tax_rate": "0.08875",
+                "unit_totals": {
+                    "tax": "887",
+                    "total": "10887",
+                    "discount": "0",
+                    "subtotal": "10000"
+                }
+            },
+            {
+                "id": "txnitm_01hv8wt98jahpbm1t1v67vqnb6",
+                "totals": {
+                    "tax": "1766",
+                    "total": "21666",
+                    "discount": "0",
+                    "subtotal": "19900"
+                },
+                "product": {
+                    "id": "pro_01gsz97mq9pa4fkyy0wqenepkz",
+                    "name": "Custom domains",
+                    "type": "standard",
+                    "status": "active",
+                    "image_url": "https://paddle.s3.amazonaws.com/user/165798/XIG7UXoJQHmlIAiKcnkA_custom-domains.png",
+                    "created_at": "2023-02-23T14:01:02.441Z",
+                    "updated_at": "2024-04-05T15:43:28.971Z",
+                    "custom_data": null,
+                    "description": "Make AeroEdit truly your own with custom domains. Custom domains reinforce your brand identity and make it easy for your team to access your account.",
+                    "tax_category": "standard",
+                    "import_meta": null
+                },
+                "price_id": "pri_01gsz98e27ak2tyhexptwc58yk",
+                "quantity": 1,
+                "tax_rate": "0.08875",
+                "unit_totals": {
+                    "tax": "1766",
+                    "total": "21666",
+                    "discount": "0",
+                    "subtotal": "19900"
+                }
+            }
+        ],
+        "payout_totals": {
+            "fee": "3311",
+            "tax": "5315",
+            "total": "65215",
+            "credit": "0",
+            "balance": "0",
+            "discount": "0",
+            "earnings": "56589",
+            "subtotal": "59900",
+            "grand_total": "65215",
+            "currency_code": "USD",
+            "credit_to_balance": "0"
+        },
+        "tax_rates_used": [
+            {
+                "totals": {
+                    "tax": "5315",
+                    "total": "65215",
+                    "discount": "0",
+                    "subtotal": "59900"
+                },
+                "tax_rate": "0.08875"
+            }
+        ],
+        "adjusted_totals": {
+            "fee": "3311",
+            "tax": "5315",
+            "total": "65215",
+            "earnings": "56589",
+            "subtotal": "59900",
+            "grand_total": "65215",
+            "currency_code": "USD"
+        }
+    },
+    "checkout": {
+        "url": "https://aeroedit.com/pay?_ptxn=txn_01hv8wptq8987qeep44cyrewp9"
+    },
+    "payments": [
+        {
+            "amount": "65215",
+            "status": "captured",
+            "created_at": "2024-04-12T10:18:33.579142Z",
+            "error_code": null,
+            "captured_at": "2024-04-12T10:18:47.635628Z",
+            "method_details": {
+                "card": {
+                    "type": "visa",
+                    "last4": "3184",
+                    "expiry_year": 2025,
+                    "expiry_month": 1,
+                    "cardholder_name": "Michael McGovern"
+                },
+                "type": "card"
+            },
+            "payment_method_id": "paymtd_01hv8x1tpjfnttxddw73xnqx6s",
+            "payment_attempt_id": "937640dd-e3dc-40df-a16c-bb75aafd8f71",
+            "stored_payment_method_id": "281ff2ca-8550-42b9-bf39-15948e7de62d"
+        },
+        {
+            "amount": "65215",
+            "status": "error",
+            "created_at": "2024-04-12T10:15:57.888183Z",
+            "error_code": "declined",
+            "captured_at": null,
+            "method_details": {
+                "card": {
+                    "type": "visa",
+                    "last4": "0002",
+                    "expiry_year": 2025,
+                    "expiry_month": 1,
+                    "cardholder_name": "Michael McGovern"
+                },
+                "type": "card"
+            },
+            "payment_method_id": "paymtd_01hv8wx2mka7dfsqjjsxh1ne7z",
+            "payment_attempt_id": "8f72cfa6-26b4-4a57-91dc-8f2708f7822d",
+            "stored_payment_method_id": "a78ece50-356f-4e0c-b72d-ad5368b0a0d9"
+        }
+    ],
+    "billed_at": "2024-04-12T10:18:48.294633Z",
+    "address_id": "add_01hv8gq3318ktkfengj2r75gfx",
+    "created_at": "2024-04-12T10:12:33.2014Z",
+    "invoice_id": "inv_01hv8x29nsh54c2pgt0hnq0zkx",
+    "updated_at": "2024-04-12T10:18:49.738971238Z",
+    "revised_at": "2024-04-12T10:19:49.738971238Z",
+    "business_id": null,
+    "custom_data": null,
+    "customer_id": "ctm_01hv6y1jedq4p1n0yqn5ba3ky4",
+    "discount_id": null,
+    "currency_code": "USD",
+    "billing_period": {
+        "ends_at": "2024-05-12T10:18:47.635628Z",
+        "starts_at": "2024-04-12T10:18:47.635628Z"
+    },
+    "invoice_number": "325-10566",
+    "billing_details": null,
+    "collection_mode": "automatic",
+    "subscription_id": "sub_01hv8x29kz0t586xy6zn1a62ny"
+}


### PR DESCRIPTION
### Added

- Added `transactions.revise` operation to revise a transaction and added `revised_at` to `Transaction` entity, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).
- Added support for `transaction.revised` notification, see [related changelog](https://developer.paddle.com/changelog/2024/revise-transaction-customer-information?utm_source=dx&utm_medium=paddle-php-sdk).

### Fixed

- Handle known entity types for events that are not supported by the current SDK version. `UndefinedEvent` will always return an `UndefinedEntity`.
