### PR TITLE
fix: undefined array key error on stored_payment_method_id

### DIFF
--- a/src/Entities/Shared/TransactionPaymentAttempt.php
+++ b/src/Entities/Shared/TransactionPaymentAttempt.php
@@ -21,7 +21,7 @@ class TransactionPaymentAttempt
     private function __construct(
         public string $paymentAttemptId,
         public string|null $paymentMethodId,
-        public string $storedPaymentMethodId,
+        public string|null $storedPaymentMethodId,
         public string $amount,
         public PaymentAttemptStatus $status,
         public ErrorCode|null $errorCode,
@@ -36,7 +36,7 @@ class TransactionPaymentAttempt
         return new self(
             $data['payment_attempt_id'],
             $data['payment_method_id'] ?? null,
-            $data['stored_payment_method_id'],
+            $data['stored_payment_method_id'] ?? null,
             $data['amount'],
             PaymentAttemptStatus::from($data['status']),
             isset($data['error_code']) ? ErrorCode::from($data['error_code']) : null,


### PR DESCRIPTION
## Undefined array key "stored_payment_method_id" error in Paddle SDK

Hey everyone,

I've been noticing a ton of errors over the past few months affecting some of my customers.

### Error message: 
`Warning: Undefined array key "stored_payment_method_id" in Paddle\SDK\Entities\Shared\TransactionPaymentAttempt::from at line 39`

This happens when I use the `getPaymentMethodChangeTransaction` method to retrieve the transaction ID in order to update the credit card in my billing dashboard.

### Possible cause?
Could the SDK be outdated compared to the API?

### Quick fix
I've implemented a temporary fix—please review it. This issue has already cost me significant revenue and customer churn.

Thanks,  
Ben
