### PR TITLE
Use script to check semver, instead of docker image

### DIFF
--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -9,6 +9,14 @@ on:
       - labeled
       - unlabeled
 
+env:
+  VALID_SEMVER_LABELS: norelease,release:major,release:minor,release:patch
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   check_labels:
     name: Check labels
@@ -19,7 +27,27 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: docker://agilepathway/pull-request-label-checker:v1.6.13@sha256:4a0bc4b4536934325ab21ea47af7a928b5c18a09b42c40275910945514a9b805
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
-          one_of: norelease,release:major,release:minor,release:patch
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const validLabels = process.env.VALID_SEMVER_LABELS.split(",");
+            const { data: labelResultList } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const prLabels = labelResultList.map(label => label.name);
+            const semverLabels = prLabels.filter(value => validLabels.includes(value));
+
+            core.info(`Valid labels: ${validLabels.join(" | ")}`);
+            core.info(`PR labels: ${prLabels.join(" | ")}`);
+            core.info(`Semver Labels: ${semverLabels.join(" | ")}`);
+
+            if (semverLabels.length == 0) {
+              core.setFailed(`SemVer label missing: You must add one of ${validLabels.join(" | ")} as a label to this PR`);
+            }
+
+            if (semverLabels.length > 1) {
+              core.setFailed("SemVer label duplicated: You must only add one SemVer label to this PR");
+            }


### PR DESCRIPTION
Use a script to check for the semver labels, instead of the docker image.

We've found better performance with this - leading to faster feedback.
It's also much more transparent about what the step is doing.