### PR TITLE
feat: Add `exchange_rate` and `fee_rate` to payout totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 - Added support for filtering events by `event_type` in event list operation, see [related changelog](https://developer.paddle.com/changelog/2025/filter-events-by-type?utm_source=dx&utm_medium=paddle-php-sdk).
 - Added support to fetch and update discount groups see [related changelog](https://developer.paddle.com/changelog/2025/discount-groups-new-api-operations?utm_source=dx&utm_medium=paddle-php-sdk)
+- Added `exchange_rate` and `fee_rate` to `TransactionPayoutTotals`
+- Added `exchange_rate` to `TransactionPayoutTotalsAdjusted`
 
 ## [1.10.0] - 2025-06-27
 

--- a/src/Entities/Shared/TransactionPayoutTotals.php
+++ b/src/Entities/Shared/TransactionPayoutTotals.php
@@ -25,6 +25,8 @@ class TransactionPayoutTotals
         public string $earnings,
         public CurrencyCodePayouts $currencyCode,
         public string $creditToBalance,
+        public string $exchangeRate,
+        public string $feeRate,
     ) {
     }
 
@@ -42,6 +44,8 @@ class TransactionPayoutTotals
             earnings: $data['earnings'] ?? null,
             currencyCode: CurrencyCodePayouts::from($data['currency_code']),
             creditToBalance: $data['credit_to_balance'],
+            exchangeRate: $data['exchange_rate'],
+            feeRate: $data['fee_rate'],
         );
     }
 }

--- a/src/Entities/Shared/TransactionPayoutTotalsAdjusted.php
+++ b/src/Entities/Shared/TransactionPayoutTotalsAdjusted.php
@@ -21,6 +21,7 @@ class TransactionPayoutTotalsAdjusted
         public ChargebackFee $chargebackFee,
         public string $earnings,
         public CurrencyCodePayouts $currencyCode,
+        public string $exchangeRate,
     ) {
     }
 
@@ -34,6 +35,7 @@ class TransactionPayoutTotalsAdjusted
             ChargebackFee::from($data['chargeback_fee']),
             $data['earnings'],
             CurrencyCodePayouts::from($data['currency_code']),
+            $data['exchange_rate'],
         );
     }
 }

--- a/src/Notifications/Entities/Shared/TransactionPayoutTotals.php
+++ b/src/Notifications/Entities/Shared/TransactionPayoutTotals.php
@@ -25,6 +25,8 @@ class TransactionPayoutTotals
         public string $earnings,
         public CurrencyCodePayouts $currencyCode,
         public string|null $creditToBalance,
+        public string|null $exchangeRate,
+        public string|null $feeRate,
     ) {
     }
 
@@ -42,6 +44,8 @@ class TransactionPayoutTotals
             earnings: $data['earnings'] ?? null,
             currencyCode: CurrencyCodePayouts::from($data['currency_code']),
             creditToBalance: $data['credit_to_balance'] ?? null,
+            exchangeRate: $data['exchange_rate'] ?? null,
+            feeRate: $data['fee_rate'] ?? null,
         );
     }
 }

--- a/src/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.php
+++ b/src/Notifications/Entities/Shared/TransactionPayoutTotalsAdjusted.php
@@ -21,6 +21,7 @@ class TransactionPayoutTotalsAdjusted
         public ChargebackFee $chargebackFee,
         public string $earnings,
         public CurrencyCodePayouts $currencyCode,
+        public string|null $exchangeRate,
     ) {
     }
 
@@ -34,6 +35,7 @@ class TransactionPayoutTotalsAdjusted
             ChargebackFee::from($data['chargeback_fee']),
             $data['earnings'],
             CurrencyCodePayouts::from($data['currency_code']),
+            $data['exchange_rate'] ?? null,
         );
     }
 }

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_default.json
@@ -878,7 +878,9 @@
           "grand_total": "40000",
           "fee": "2050",
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147",
+          "fee_rate": "0"
         },
         "adjusted_payout_totals": {
           "subtotal": "40000",
@@ -890,7 +892,8 @@
             "original": null
           },
           "earnings": "37950",
-          "currency_code": "USD"
+          "currency_code": "USD",
+          "exchange_rate": "0.70194147"
         },
         "line_items": [
           {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_one.json
@@ -864,7 +864,9 @@
                     "grand_total": "40000",
                     "fee": "2050",
                     "earnings": "37950",
-                    "currency_code": "USD"
+                    "currency_code": "USD",
+                    "exchange_rate": "0.70194147",
+                    "fee_rate": "0"
                 },
                 "adjusted_payout_totals": {
                     "subtotal": "40000",
@@ -876,7 +878,8 @@
                         "original": null
                     },
                     "earnings": "37950",
-                    "currency_code": "USD"
+                    "currency_code": "USD",
+                    "exchange_rate": "0.70194147"
                 },
                 "line_items": [
                     {

--- a/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/response/list_paginated_page_two.json
@@ -864,7 +864,9 @@
                     "grand_total": "40000",
                     "fee": "2050",
                     "earnings": "37950",
-                    "currency_code": "USD"
+                    "currency_code": "USD",
+                    "exchange_rate": "0.70194147",
+                    "fee_rate": "0"
                 },
                 "adjusted_payout_totals": {
                     "subtotal": "40000",
@@ -876,7 +878,8 @@
                         "original": null
                     },
                     "earnings": "37950",
-                    "currency_code": "USD"
+                    "currency_code": "USD",
+                    "exchange_rate": "0.70194147"
                 },
                 "line_items": [
                     {

--- a/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
+++ b/tests/Unit/Entities/_fixtures/notification/entity/transaction.revised.json
@@ -228,7 +228,9 @@
             "subtotal": "59900",
             "grand_total": "65215",
             "currency_code": "USD",
-            "credit_to_balance": "0"
+            "credit_to_balance": "0",
+            "exchange_rate": "0.70194147",
+            "fee_rate": "0"
         },
         "tax_rates_used": [
             {
@@ -241,6 +243,19 @@
                 "tax_rate": "0.08875"
             }
         ],
+        "adjusted_payout_totals": {
+            "fee": "3311",
+            "tax": "5315",
+            "total": "65215",
+            "chargeback_fee": {
+                "amount": "0",
+                "original": null
+            },
+            "earnings": "56589",
+            "subtotal": "59900",
+            "currency_code": "USD",
+            "exchange_rate": "0.70194147"
+        },
         "adjusted_totals": {
             "fee": "3311",
             "tax": "5315",


### PR DESCRIPTION
### Added

- Added `exchange_rate` and `fee_rate` to `TransactionPayoutTotals`
- Added `exchange_rate` to `TransactionPayoutTotalsAdjusted`
