### PR TITLE
feat: Add `retryAfter` property to `ApiError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [Unreleased]
+
+### Added
+
+- `ApiError` will now have `retryAfter` property set for [too_many_requests](https://developer.paddle.com/errors/shared/too_many_requests) errors
+
 ## [1.11.0] - 2025-09-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ $paddle = new Client('API_KEY');
 $product = $paddle->products->get('id');
 ```
 
+### Error Handling
+
+If a request fails, Paddle throws an `ApiError` exception that contains the same information as [errors returned by the API](https://developer.paddle.com/api-reference/about/errors?utm_source=dx&utm_medium=paddle-php-sdk). You can use the `errorCode` attribute to search an error in [the error reference](https://developer.paddle.com/errors/overview?utm_source=dx&utm_medium=paddle-php-sdk) and to handle the error in your app. Validation errors also return an array of `errors` that tell you which fields failed validation. The `retryAfter` property will be set for `too_many_requests` errors.
+
+This example shows how to handle an error with the code `conflict`:
+
+```php
+use Paddle\SDK\Exceptions\ApiError;
+
+try {
+    // Call functions from the SDK
+} catch (ApiError $e) {
+    // $e->errorCode will always follow the error code defined in our documentation
+    if ($e->errorCode === 'conflict') {
+        // Handle Conflict error
+    }
+}
+```
+
 ## Resources
 
 ### Webhook signature verification

--- a/src/Exceptions/ApiError.php
+++ b/src/Exceptions/ApiError.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Paddle\SDK\Exceptions;
 
 use Psr\Http\Client\ClientExceptionInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class ApiError extends \Exception implements ClientExceptionInterface
 {
@@ -26,7 +25,7 @@ class ApiError extends \Exception implements ClientExceptionInterface
         parent::__construct($this->detail);
     }
 
-    public static function fromErrorData(array $error, ResponseInterface|null $response = null): static
+    public static function fromErrorData(array $error, int|null $retryAfter = null): static
     {
         $apiError = new static(
             $error['type'],
@@ -39,8 +38,7 @@ class ApiError extends \Exception implements ClientExceptionInterface
             ),
         );
 
-        $retryAfterHeader = $response?->getHeader('Retry-After')[0] ?? null;
-        $apiError->retryAfter = $retryAfterHeader ? intval($retryAfterHeader) : null;
+        $apiError->retryAfter = $retryAfter;
 
         return $apiError;
     }

--- a/src/Exceptions/ApiError.php
+++ b/src/Exceptions/ApiError.php
@@ -12,7 +12,7 @@ class ApiError extends \Exception implements ClientExceptionInterface
     /** @var array<FieldError> */
     public array $fieldErrors;
 
-    public readonly int|null $retryAfter;
+    public int|null $retryAfter = null;
 
     final public function __construct(
         public string $type,

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -15,7 +15,7 @@ class ResponseParser
     /**
      * @throws ApiError When the API response contains errors
      */
-    public function __construct(ResponseInterface $response)
+    public function __construct(private readonly ResponseInterface $response)
     {
         try {
             $this->body = json_decode(
@@ -60,7 +60,7 @@ class ResponseParser
         /** @var class-string<ApiError> $exceptionClass */
         $exceptionClass = $this->findExceptionClassFromCode($this->body['error']['code'] ?? 'shared_error');
 
-        throw $exceptionClass::fromErrorData($this->body['error']);
+        throw $exceptionClass::fromErrorData($this->body['error'], $this->response);
     }
 
     /**

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -60,7 +60,10 @@ class ResponseParser
         /** @var class-string<ApiError> $exceptionClass */
         $exceptionClass = $this->findExceptionClassFromCode($this->body['error']['code'] ?? 'shared_error');
 
-        throw $exceptionClass::fromErrorData($this->body['error'], $this->response);
+        $retryAfterHeader = $this->response->getHeader('Retry-After')[0] ?? null;
+        $retryAfter = $retryAfterHeader ? intval($retryAfterHeader) : null;
+
+        throw $exceptionClass::fromErrorData($this->body['error'], $retryAfter);
     }
 
     /**

--- a/tests/Unit/ResponseParserTest.php
+++ b/tests/Unit/ResponseParserTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Unit;
+
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\ResponseParser;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ResponseParserTest extends TestCase
+{
+    /** @test */
+    public function it_throws_api_error(): void
+    {
+        $responseBody = json_encode([
+            'error' => [
+                'type' => 'request_error',
+                'code' => 'conflict',
+                'detail' => 'Request conflicts with another change.',
+                'documentation_url' => 'https://developer.paddle.com/errors/shared/conflict',
+                'errors' => [],
+            ],
+        ]);
+
+        /** @var ResponseInterface $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('__toString')->willReturn($responseBody);
+        $response->method('getBody')->willReturn($stream);
+        $response->method('getStatusCode')->willReturn(409);
+        $response->method('getHeader')->with('Retry-After')->willReturn([]);
+
+        $this->expectException(ApiError::class);
+
+        try {
+            new ResponseParser($response);
+        } catch (ApiError $e) {
+            self::assertSame('conflict', $e->errorCode);
+            self::assertNull($e->retryAfter);
+            throw $e; // rethrow to satisfy expectException
+        }
+    }
+
+    /** @test */
+    public function it_throws_api_error_with_retry_after_for_too_many_requests(): void
+    {
+        $responseBody = json_encode([
+            'error' => [
+                'type' => 'request_error',
+                'code' => 'too_many_requests',
+                'detail' => 'IP address exceeded the allowed rate limit. Retry after the number of seconds in the Retry-After header.',
+                'documentation_url' => 'https://developer.paddle.com/errors/shared/too_many_requests',
+                'errors' => [],
+            ],
+        ]);
+
+        /** @var ResponseInterface $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('__toString')->willReturn($responseBody);
+        $response->method('getBody')->willReturn($stream);
+        $response->method('getStatusCode')->willReturn(429);
+        $response->method('getHeader')->with('Retry-After')->willReturn(['42']);
+
+        $this->expectException(ApiError::class);
+
+        try {
+            new ResponseParser($response);
+        } catch (ApiError $e) {
+            self::assertSame('too_many_requests', $e->errorCode);
+            self::assertSame(42, $e->retryAfter);
+            throw $e; // rethrow to satisfy expectException
+        }
+    }
+}


### PR DESCRIPTION
### Added

- `ApiError` will now have `retryAfter` property set for [too_many_requests](https://developer.paddle.com/errors/shared/too_many_requests) errors