### PR TITLE
feat: Add support for non-catalog discounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx
 
 ### Added
 
+- Non-catalog discounts on Transactions, see [changelog](https://developer.paddle.com/changelog/2025/custom-discounts?utm_source=dx&utm_medium=paddle-php-sdk)
 - `ApiError` will now have `retryAfter` property set for [too_many_requests](https://developer.paddle.com/errors/shared/too_many_requests) errors
 
 ## [1.11.0] - 2025-09-15

--- a/src/Resources/Transactions/Operations/CreateTransaction.php
+++ b/src/Resources/Transactions/Operations/CreateTransaction.php
@@ -16,6 +16,7 @@ use Paddle\SDK\Entities\Transaction\TransactionTimePeriod;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItem;
 use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice;
+use Paddle\SDK\Resources\Transactions\Operations\Discount\TransactionNonCatalogDiscount;
 use Paddle\SDK\Undefined;
 
 class CreateTransaction implements \JsonSerializable
@@ -38,6 +39,7 @@ class CreateTransaction implements \JsonSerializable
         public readonly BillingDetails|Undefined|null $billingDetails = new Undefined(),
         public readonly TransactionTimePeriod|Undefined|null $billingPeriod = new Undefined(),
         public readonly Checkout|Undefined|null $checkout = new Undefined(),
+        public readonly TransactionNonCatalogDiscount|Undefined|null $discount = new Undefined(),
     ) {
     }
 
@@ -56,6 +58,7 @@ class CreateTransaction implements \JsonSerializable
             'billing_details' => $this->billingDetails,
             'billing_period' => $this->billingPeriod,
             'checkout' => $this->checkout,
+            'discount' => $this->discount,
         ]);
     }
 }

--- a/src/Resources/Transactions/Operations/Discount/TransactionNonCatalogDiscount.php
+++ b/src/Resources/Transactions/Operations/Discount/TransactionNonCatalogDiscount.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Transactions\Operations\Discount;
+
+use Paddle\SDK\Entities\Discount\DiscountType;
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class TransactionNonCatalogDiscount implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    /**
+     * @param array<string>|null $restrictTo
+     */
+    public function __construct(
+        public readonly string $amount,
+        public readonly string $description,
+        public readonly DiscountType $type,
+        public readonly bool|Undefined $recur = new Undefined(),
+        public readonly int|Undefined|null $maximumRecurringIntervals = new Undefined(),
+        public readonly CustomData|Undefined|null $customData = new Undefined(),
+        public readonly array|Undefined|null $restrictTo = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'amount' => $this->amount,
+            'description' => $this->description,
+            'type' => $this->type,
+            'recur' => $this->recur,
+            'maximum_recurring_intervals' => $this->maximumRecurringIntervals,
+            'custom_data' => $this->customData,
+            'restrict_to' => $this->restrictTo,
+        ]);
+    }
+}

--- a/src/Resources/Transactions/Operations/PreviewTransaction.php
+++ b/src/Resources/Transactions/Operations/PreviewTransaction.php
@@ -10,6 +10,7 @@ use Paddle\SDK\Entities\Shared\CurrencyCode;
 use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithNonCatalogPrice as EntityItemPreviewWithNonCatalogPrice;
 use Paddle\SDK\Entities\Transaction\TransactionItemPreviewWithPriceId as EntityItemPreviewWithPriceId;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Discount\TransactionNonCatalogDiscount;
 use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithNonCatalogPrice;
 use Paddle\SDK\Resources\Transactions\Operations\Preview\TransactionItemPreviewWithPriceId;
 use Paddle\SDK\Undefined;
@@ -32,6 +33,7 @@ class PreviewTransaction implements \JsonSerializable
         public readonly string|Undefined|null $customerIpAddress = new Undefined(),
         public readonly AddressPreview|Undefined|null $address = new Undefined(),
         public readonly bool|Undefined $ignoreTrials = new Undefined(),
+        public readonly TransactionNonCatalogDiscount|Undefined|null $discount = new Undefined(),
     ) {
     }
 
@@ -48,6 +50,7 @@ class PreviewTransaction implements \JsonSerializable
             'customer_ip_address' => $this->customerIpAddress,
             'address' => $this->address,
             'ignore_trials' => $this->ignoreTrials,
+            'discount' => $this->discount,
         ]);
     }
 }

--- a/src/Resources/Transactions/Operations/UpdateTransaction.php
+++ b/src/Resources/Transactions/Operations/UpdateTransaction.php
@@ -13,6 +13,7 @@ use Paddle\SDK\Entities\Shared\TransactionStatus;
 use Paddle\SDK\Entities\Transaction\TransactionTimePeriod;
 use Paddle\SDK\Entities\Transaction\TransactionUpdateTransactionItem;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Transactions\Operations\Discount\TransactionNonCatalogDiscount;
 use Paddle\SDK\Resources\Transactions\Operations\Update\TransactionUpdateItem;
 use Paddle\SDK\Resources\Transactions\Operations\Update\TransactionUpdateItemWithPrice;
 use Paddle\SDK\Undefined;
@@ -37,6 +38,7 @@ class UpdateTransaction implements \JsonSerializable
         public readonly TransactionTimePeriod|Undefined|null $billingPeriod = new Undefined(),
         public readonly array|Undefined $items = new Undefined(),
         public readonly Checkout|Undefined|null $checkout = new Undefined(),
+        public readonly TransactionNonCatalogDiscount|Undefined|null $discount = new Undefined(),
     ) {
     }
 
@@ -55,6 +57,7 @@ class UpdateTransaction implements \JsonSerializable
             'billing_period' => $this->billingPeriod,
             'items' => $this->items,
             'checkout' => $this->checkout,
+            'discount' => $this->discount,
         ]);
     }
 }

--- a/tests/Functional/Resources/Transactions/TransactionsClientTest.php
+++ b/tests/Functional/Resources/Transactions/TransactionsClientTest.php
@@ -41,6 +41,7 @@ use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItem;
 use Paddle\SDK\Resources\Transactions\Operations\Create\TransactionCreateItemWithPrice;
 use Paddle\SDK\Resources\Transactions\Operations\CreateTransaction;
+use Paddle\SDK\Resources\Transactions\Operations\Discount\TransactionNonCatalogDiscount;
 use Paddle\SDK\Resources\Transactions\Operations\GetTransactionInvoice;
 use Paddle\SDK\Resources\Transactions\Operations\List\Includes;
 use Paddle\SDK\Resources\Transactions\Operations\List\Origin;
@@ -149,6 +150,42 @@ class TransactionsClientTest extends TestCase
 
     public static function createOperationsProvider(): \Generator
     {
+        yield 'Create with non-catalog discount minimal' => [
+            new CreateTransaction(
+                items: [
+                    new TransactionCreateItem('pri_01he5kxqey1k8ankgef29cj4bv', 1),
+                ],
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '10',
+                    description: 'Promo',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Percentage(),
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/minimal_entity')),
+            self::readRawJsonFixture('request/create_with_noncatalog_discount_minimal'),
+        ];
+
+        yield 'Create with non-catalog discount full' => [
+            new CreateTransaction(
+                items: [
+                    new TransactionCreateItem('pri_01he5kxqey1k8ankgef29cj4bv', 1),
+                ],
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '500',
+                    description: 'Black Friday',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Flat(),
+                    recur: true,
+                    maximumRecurringIntervals: 3,
+                    customData: new CustomData(['source' => 'bf2025']),
+                    restrictTo: [
+                        'pro_01gsz4t5hdjse780zja8vvr7jg',
+                        'pro_01gsz4s0w61y0pp88528f1wvvb',
+                    ],
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/minimal_entity')),
+            self::readRawJsonFixture('request/create_with_noncatalog_discount_full'),
+        ];
         yield 'Basic Create' => [
             new CreateTransaction(
                 items: [
@@ -439,6 +476,37 @@ class TransactionsClientTest extends TestCase
             ),
             new Response(200, body: self::readRawJsonFixture('response/full_entity')),
             self::readRawJsonFixture('request/update_partial'),
+        ];
+
+        yield 'Update with non-catalog discount minimal' => [
+            new UpdateTransaction(
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '10',
+                    description: 'Promo',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Percentage(),
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/update_with_noncatalog_discount_minimal'),
+        ];
+
+        yield 'Update with non-catalog discount full' => [
+            new UpdateTransaction(
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '500',
+                    description: 'Black Friday',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Flat(),
+                    recur: true,
+                    maximumRecurringIntervals: 3,
+                    customData: new CustomData(['source' => 'bf2025']),
+                    restrictTo: [
+                        'pro_01gsz4t5hdjse780zja8vvr7jg',
+                        'pro_01gsz4s0w61y0pp88528f1wvvb',
+                    ],
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/update_with_noncatalog_discount_full'),
         ];
     }
 
@@ -903,6 +971,43 @@ class TransactionsClientTest extends TestCase
             ),
             new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
             self::readRawJsonFixture('request/preview_with_non_catalog_price_and_product'),
+        ];
+
+        yield 'Preview with non-catalog discount minimal' => [
+            new PreviewTransaction(
+                items: [
+                    new TransactionItemPreviewWithPriceId('pri_01he5kxqey1k8ankgef29cj4bv', 1, true),
+                ],
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '5',
+                    description: 'Black Friday',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Percentage(),
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
+            self::readRawJsonFixture('request/preview_with_noncatalog_discount_minimal'),
+        ];
+
+        yield 'Preview with non-catalog discount full' => [
+            new PreviewTransaction(
+                items: [
+                    new TransactionItemPreviewWithPriceId('pri_01he5kxqey1k8ankgef29cj4bv', 1, true),
+                ],
+                discount: new TransactionNonCatalogDiscount(
+                    amount: '500',
+                    description: 'Black Friday',
+                    type: \Paddle\SDK\Entities\Discount\DiscountType::Flat(),
+                    recur: true,
+                    maximumRecurringIntervals: 3,
+                    customData: new CustomData(['source' => 'bf2025']),
+                    restrictTo: [
+                        'pro_01gsz4t5hdjse780zja8vvr7jg',
+                        'pro_01gsz4s0w61y0pp88528f1wvvb',
+                    ],
+                ),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_entity')),
+            self::readRawJsonFixture('request/preview_with_noncatalog_discount_full'),
         ];
     }
 

--- a/tests/Functional/Resources/Transactions/_fixtures/request/create_with_noncatalog_discount_full.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/create_with_noncatalog_discount_full.json
@@ -1,0 +1,22 @@
+{
+  "items": [
+    {
+      "quantity": 1,
+      "price_id": "pri_01he5kxqey1k8ankgef29cj4bv"
+    }
+  ],
+  "discount": {
+    "amount": "500",
+    "description": "Black Friday",
+    "type": "flat",
+    "recur": true,
+    "maximum_recurring_intervals": 3,
+    "custom_data": {
+      "source": "bf2025"
+    },
+    "restrict_to": [
+      "pro_01gsz4t5hdjse780zja8vvr7jg",
+      "pro_01gsz4s0w61y0pp88528f1wvvb"
+    ]
+  }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/create_with_noncatalog_discount_minimal.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/create_with_noncatalog_discount_minimal.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    {
+      "quantity": 1,
+      "price_id": "pri_01he5kxqey1k8ankgef29cj4bv"
+    }
+  ],
+  "discount": {
+    "amount": "10",
+    "description": "Promo",
+    "type": "percentage"
+  }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_noncatalog_discount_full.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_noncatalog_discount_full.json
@@ -1,0 +1,23 @@
+{
+  "items": [
+    {
+      "quantity": 1,
+      "price_id": "pri_01he5kxqey1k8ankgef29cj4bv",
+      "include_in_totals": true
+    }
+  ],
+  "discount": {
+    "amount": "500",
+    "description": "Black Friday",
+    "type": "flat",
+    "recur": true,
+    "maximum_recurring_intervals": 3,
+    "custom_data": {
+      "source": "bf2025"
+    },
+    "restrict_to": [
+      "pro_01gsz4t5hdjse780zja8vvr7jg",
+      "pro_01gsz4s0w61y0pp88528f1wvvb"
+    ]
+  }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_noncatalog_discount_minimal.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/preview_with_noncatalog_discount_minimal.json
@@ -1,0 +1,14 @@
+{
+  "items": [
+    {
+      "quantity": 1,
+      "price_id": "pri_01he5kxqey1k8ankgef29cj4bv",
+      "include_in_totals": true
+    }
+  ],
+  "discount": {
+    "amount": "5",
+    "description": "Black Friday",
+    "type": "percentage"
+  }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/update_with_noncatalog_discount_full.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/update_with_noncatalog_discount_full.json
@@ -1,0 +1,16 @@
+{
+  "discount": {
+    "amount": "500",
+    "description": "Black Friday",
+    "type": "flat",
+    "recur": true,
+    "maximum_recurring_intervals": 3,
+    "custom_data": {
+      "source": "bf2025"
+    },
+    "restrict_to": [
+      "pro_01gsz4t5hdjse780zja8vvr7jg",
+      "pro_01gsz4s0w61y0pp88528f1wvvb"
+    ]
+  }
+}

--- a/tests/Functional/Resources/Transactions/_fixtures/request/update_with_noncatalog_discount_minimal.json
+++ b/tests/Functional/Resources/Transactions/_fixtures/request/update_with_noncatalog_discount_minimal.json
@@ -1,0 +1,7 @@
+{
+  "discount": {
+    "amount": "10",
+    "description": "Promo",
+    "type": "percentage"
+  }
+}


### PR DESCRIPTION
### Added

- Non-catalog discounts on Transactions, see [changelog](https://developer.paddle.com/changelog/2025/custom-discounts?utm_source=dx&utm_medium=paddle-php-sdk)