### PR TITLE
docs(release): v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [Unreleased]
+## [1.12.0] - 2025-10-07
 
 ### Added
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -53,7 +53,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.11.0';
+    private const SDK_VERSION = '1.12.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;


### PR DESCRIPTION
## [[1.12.0] - 2025-10-07](https://github.com/PaddleHQ/paddle-php-sdk/compare/v1.11.0...docs/release-1-12-0)

### Added

- Non-catalog discounts on Transactions, see [changelog](https://developer.paddle.com/changelog/2025/custom-discounts?utm_source=dx&utm_medium=paddle-php-sdk)
- Added support for new payment methods `blik`, `mb_way`, `pix` and `upi`. See [related changelog](https://developer.paddle.com/changelog/2025/blik-mbway-payment-methods?utm_source=dx&utm_medium=paddle-php-sdk).
- Support `retained_fee` field on totals objects to show the fees retained by Paddle for the adjustment.
- `ApiError` will now have `retryAfter` property set for [too_many_requests](https://developer.paddle.com/errors/shared/too_many_requests) errors