### PR TITLE
feat: Add support for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [1.17.0] - 2026-03-30
+
+### Added
+
+- Added support for metrics endpoints. See [related changelog](https://developer.paddle.com/changelog/2026/metrics-api?utm_source=dx&utm_medium=paddle-php-sdk)
+  - `Client->metrics->getMonthlyRecurringRevenue()`
+  - `Client->metrics->getMonthlyRecurringRevenueChange()`
+  - `Client->metrics->getActiveSubscribers()`
+  - `Client->metrics->getRevenue()`
+  - `Client->metrics->getRefunds()`
+  - `Client->metrics->getChargebacks()`
+  - `Client->metrics->getCheckoutConversion()`
+
 ## [1.16.0] - 2026-02-04
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,6 +28,7 @@ use Paddle\SDK\Resources\DiscountGroups\DiscountGroupsClient;
 use Paddle\SDK\Resources\Discounts\DiscountsClient;
 use Paddle\SDK\Resources\Events\EventsClient;
 use Paddle\SDK\Resources\EventTypes\EventTypesClient;
+use Paddle\SDK\Resources\Metrics\MetricsClient;
 use Paddle\SDK\Resources\NotificationLogs\NotificationLogsClient;
 use Paddle\SDK\Resources\Notifications\NotificationsClient;
 use Paddle\SDK\Resources\NotificationSettings\NotificationSettingsClient;
@@ -53,7 +54,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.16.0';
+    private const SDK_VERSION = '1.17.0';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;
@@ -82,6 +83,7 @@ class Client
     public readonly SimulationRunsClient $simulationRuns;
     public readonly SimulationRunEventsClient $simulationRunEvents;
     public readonly SimulationTypesClient $simulationTypes;
+    public readonly MetricsClient $metrics;
 
     private readonly HttpAsyncClient $httpClient;
     private readonly RequestFactoryInterface $requestFactory;
@@ -133,6 +135,7 @@ class Client
         $this->simulationRuns = new SimulationRunsClient($this);
         $this->simulationRunEvents = new SimulationRunEventsClient($this);
         $this->simulationTypes = new SimulationTypesClient($this);
+        $this->metrics = new MetricsClient($this);
     }
 
     public function getRaw(string|UriInterface $uri, array|HasParameters $parameters = []): ResponseInterface

--- a/src/Entities/Metrics/MetricsActiveSubscribers.php
+++ b/src/Entities/Metrics/MetricsActiveSubscribers.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+
+class MetricsActiveSubscribers implements Entity
+{
+    /**
+     * @param array<MetricsCountDatapoint> $timeseries
+     */
+    private function __construct(
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timeseries: array_map(
+                fn (array $dp): MetricsCountDatapoint => MetricsCountDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsAmountDatapoint.php
+++ b/src/Entities/Metrics/MetricsAmountDatapoint.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Metrics;
 
+use Paddle\SDK\Entities\DateTime;
+
 class MetricsAmountDatapoint
 {
     private function __construct(
-        public string $timestamp,
+        public \DateTimeInterface $timestamp,
         public string $amount,
     ) {
     }
@@ -22,7 +24,7 @@ class MetricsAmountDatapoint
     public static function from(array $data): self
     {
         return new self(
-            timestamp: $data['timestamp'],
+            timestamp: DateTime::from($data['timestamp']),
             amount: $data['amount'],
         );
     }

--- a/src/Entities/Metrics/MetricsAmountDatapoint.php
+++ b/src/Entities/Metrics/MetricsAmountDatapoint.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+class MetricsAmountDatapoint
+{
+    private function __construct(
+        public string $timestamp,
+        public string $amount,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timestamp: $data['timestamp'],
+            amount: $data['amount'],
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsChargebacks.php
+++ b/src/Entities/Metrics/MetricsChargebacks.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+
+class MetricsChargebacks implements Entity
+{
+    /**
+     * @param array<MetricsCountDatapoint> $timeseries
+     */
+    private function __construct(
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timeseries: array_map(
+                fn (array $dp): MetricsCountDatapoint => MetricsCountDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsCheckoutConversion.php
+++ b/src/Entities/Metrics/MetricsCheckoutConversion.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+
+class MetricsCheckoutConversion implements Entity
+{
+    /**
+     * @param array<MetricsCheckoutConversionDatapoint> $timeseries
+     */
+    private function __construct(
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timeseries: array_map(
+                fn (array $dp): MetricsCheckoutConversionDatapoint => MetricsCheckoutConversionDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsCheckoutConversionDatapoint.php
+++ b/src/Entities/Metrics/MetricsCheckoutConversionDatapoint.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Metrics;
 
+use Paddle\SDK\Entities\DateTime;
+
 class MetricsCheckoutConversionDatapoint
 {
     private function __construct(
-        public string $timestamp,
+        public \DateTimeInterface $timestamp,
         public int $count,
         public int $completedCount,
         public string $rate,
@@ -24,7 +26,7 @@ class MetricsCheckoutConversionDatapoint
     public static function from(array $data): self
     {
         return new self(
-            timestamp: $data['timestamp'],
+            timestamp: DateTime::from($data['timestamp']),
             count: $data['count'],
             completedCount: $data['completed_count'],
             rate: $data['rate'],

--- a/src/Entities/Metrics/MetricsCheckoutConversionDatapoint.php
+++ b/src/Entities/Metrics/MetricsCheckoutConversionDatapoint.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+class MetricsCheckoutConversionDatapoint
+{
+    private function __construct(
+        public string $timestamp,
+        public int $count,
+        public int $completedCount,
+        public string $rate,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timestamp: $data['timestamp'],
+            count: $data['count'],
+            completedCount: $data['completed_count'],
+            rate: $data['rate'],
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsCountDatapoint.php
+++ b/src/Entities/Metrics/MetricsCountDatapoint.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Metrics;
 
+use Paddle\SDK\Entities\DateTime;
+
 class MetricsCountDatapoint
 {
     private function __construct(
-        public string $timestamp,
+        public \DateTimeInterface $timestamp,
         public int $count,
     ) {
     }
@@ -22,7 +24,7 @@ class MetricsCountDatapoint
     public static function from(array $data): self
     {
         return new self(
-            timestamp: $data['timestamp'],
+            timestamp: DateTime::from($data['timestamp']),
             count: $data['count'],
         );
     }

--- a/src/Entities/Metrics/MetricsCountDatapoint.php
+++ b/src/Entities/Metrics/MetricsCountDatapoint.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+class MetricsCountDatapoint
+{
+    private function __construct(
+        public string $timestamp,
+        public int $count,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timestamp: $data['timestamp'],
+            count: $data['count'],
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsInterval.php
+++ b/src/Entities/Metrics/MetricsInterval.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\PaddleEnum;
+
+/**
+ * @method static MetricsInterval Day()
+ */
+final class MetricsInterval extends PaddleEnum
+{
+    private const Day = 'day';
+}

--- a/src/Entities/Metrics/MetricsMonthlyRecurringRevenue.php
+++ b/src/Entities/Metrics/MetricsMonthlyRecurringRevenue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+use Paddle\SDK\Entities\Shared\CurrencyCode;
+
+class MetricsMonthlyRecurringRevenue implements Entity
+{
+    /**
+     * @param array<MetricsAmountDatapoint> $timeseries
+     */
+    private function __construct(
+        public CurrencyCode $currencyCode,
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            currencyCode: CurrencyCode::from($data['currency_code']),
+            timeseries: array_map(
+                fn (array $dp): MetricsAmountDatapoint => MetricsAmountDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsMonthlyRecurringRevenueChange.php
+++ b/src/Entities/Metrics/MetricsMonthlyRecurringRevenueChange.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+use Paddle\SDK\Entities\Shared\CurrencyCode;
+
+class MetricsMonthlyRecurringRevenueChange implements Entity
+{
+    /**
+     * @param array<MetricsAmountDatapoint> $timeseries
+     */
+    private function __construct(
+        public CurrencyCode $currencyCode,
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            currencyCode: CurrencyCode::from($data['currency_code']),
+            timeseries: array_map(
+                fn (array $dp): MetricsAmountDatapoint => MetricsAmountDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsRefunds.php
+++ b/src/Entities/Metrics/MetricsRefunds.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+use Paddle\SDK\Entities\Shared\CurrencyCode;
+
+class MetricsRefunds implements Entity
+{
+    /**
+     * @param array<MetricsAmountDatapoint> $timeseries
+     */
+    private function __construct(
+        public CurrencyCode $currencyCode,
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            currencyCode: CurrencyCode::from($data['currency_code']),
+            timeseries: array_map(
+                fn (array $dp): MetricsAmountDatapoint => MetricsAmountDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsRevenue.php
+++ b/src/Entities/Metrics/MetricsRevenue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+use Paddle\SDK\Entities\DateTime;
+use Paddle\SDK\Entities\Entity;
+use Paddle\SDK\Entities\Shared\CurrencyCode;
+
+class MetricsRevenue implements Entity
+{
+    /**
+     * @param array<MetricsRevenueDatapoint> $timeseries
+     */
+    private function __construct(
+        public CurrencyCode $currencyCode,
+        public array $timeseries,
+        public \DateTimeInterface $startsAt,
+        public \DateTimeInterface $endsAt,
+        public MetricsInterval $interval,
+        public \DateTimeInterface $updatedAt,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            currencyCode: CurrencyCode::from($data['currency_code']),
+            timeseries: array_map(
+                fn (array $dp): MetricsRevenueDatapoint => MetricsRevenueDatapoint::from($dp),
+                $data['timeseries'] ?? [],
+            ),
+            startsAt: DateTime::from($data['starts_at']),
+            endsAt: DateTime::from($data['ends_at']),
+            interval: MetricsInterval::from($data['interval']),
+            updatedAt: DateTime::from($data['updated_at']),
+        );
+    }
+}

--- a/src/Entities/Metrics/MetricsRevenueDatapoint.php
+++ b/src/Entities/Metrics/MetricsRevenueDatapoint.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Metrics;
 
+use Paddle\SDK\Entities\DateTime;
+
 class MetricsRevenueDatapoint
 {
     private function __construct(
-        public string $timestamp,
+        public \DateTimeInterface $timestamp,
         public string $amount,
         public int $count,
     ) {
@@ -23,7 +25,7 @@ class MetricsRevenueDatapoint
     public static function from(array $data): self
     {
         return new self(
-            timestamp: $data['timestamp'],
+            timestamp: DateTime::from($data['timestamp']),
             amount: $data['amount'],
             count: $data['count'],
         );

--- a/src/Entities/Metrics/MetricsRevenueDatapoint.php
+++ b/src/Entities/Metrics/MetricsRevenueDatapoint.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Entities\Metrics;
+
+class MetricsRevenueDatapoint
+{
+    private function __construct(
+        public string $timestamp,
+        public string $amount,
+        public int $count,
+    ) {
+    }
+
+    public static function from(array $data): self
+    {
+        return new self(
+            timestamp: $data['timestamp'],
+            amount: $data['amount'],
+            count: $data['count'],
+        );
+    }
+}

--- a/src/Resources/Metrics/MetricsClient.php
+++ b/src/Resources/Metrics/MetricsClient.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Metrics;
+
+use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Metrics\MetricsActiveSubscribers;
+use Paddle\SDK\Entities\Metrics\MetricsChargebacks;
+use Paddle\SDK\Entities\Metrics\MetricsCheckoutConversion;
+use Paddle\SDK\Entities\Metrics\MetricsMonthlyRecurringRevenue;
+use Paddle\SDK\Entities\Metrics\MetricsMonthlyRecurringRevenueChange;
+use Paddle\SDK\Entities\Metrics\MetricsRefunds;
+use Paddle\SDK\Entities\Metrics\MetricsRevenue;
+use Paddle\SDK\Exceptions\ApiError;
+use Paddle\SDK\Exceptions\SdkExceptions\MalformedResponse;
+use Paddle\SDK\Resources\Metrics\Operations\GetMetrics;
+use Paddle\SDK\ResponseParser;
+
+class MetricsClient
+{
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getMonthlyRecurringRevenue(GetMetrics $operation): MetricsMonthlyRecurringRevenue
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/monthly-recurring-revenue', $operation),
+        );
+
+        return MetricsMonthlyRecurringRevenue::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getMonthlyRecurringRevenueChange(GetMetrics $operation): MetricsMonthlyRecurringRevenueChange
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/monthly-recurring-revenue-change', $operation),
+        );
+
+        return MetricsMonthlyRecurringRevenueChange::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getActiveSubscribers(GetMetrics $operation): MetricsActiveSubscribers
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/active-subscribers', $operation),
+        );
+
+        return MetricsActiveSubscribers::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getRevenue(GetMetrics $operation): MetricsRevenue
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/revenue', $operation),
+        );
+
+        return MetricsRevenue::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getRefunds(GetMetrics $operation): MetricsRefunds
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/refunds', $operation),
+        );
+
+        return MetricsRefunds::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getChargebacks(GetMetrics $operation): MetricsChargebacks
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/chargebacks', $operation),
+        );
+
+        return MetricsChargebacks::from($parser->getData());
+    }
+
+    /**
+     * @throws ApiError          On a generic API error
+     * @throws MalformedResponse If the API response was not parsable
+     */
+    public function getCheckoutConversion(GetMetrics $operation): MetricsCheckoutConversion
+    {
+        $parser = new ResponseParser(
+            $this->client->getRaw('/metrics/checkout-conversion', $operation),
+        );
+
+        return MetricsCheckoutConversion::from($parser->getData());
+    }
+}

--- a/src/Resources/Metrics/Operations/GetMetrics.php
+++ b/src/Resources/Metrics/Operations/GetMetrics.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Metrics\Operations;
+
+use Paddle\SDK\HasParameters;
+
+class GetMetrics implements HasParameters
+{
+    private const DATE_FORMAT = '/^\d{4}-\d{2}-\d{2}$/';
+
+    public function __construct(
+        private readonly string $from,
+        private readonly string $to,
+    ) {
+        self::validateDate($from, 'from');
+        self::validateDate($to, 'to');
+    }
+
+    public function getParameters(): array
+    {
+        return [
+            'from' => $this->from,
+            'to' => $this->to,
+        ];
+    }
+
+    private static function validateDate(string $value, string $field): void
+    {
+        if (preg_match(self::DATE_FORMAT, $value) !== 1) {
+            throw new \InvalidArgumentException(sprintf("'%s' must be a date string in YYYY-MM-DD format, got '%s'", $field, $value));
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat('Y-m-d', $value);
+        if ($parsed === false || $parsed->format('Y-m-d') !== $value) {
+            throw new \InvalidArgumentException(sprintf("'%s' must be a valid date in YYYY-MM-DD format, got '%s'", $field, $value));
+        }
+    }
+}

--- a/tests/Functional/Resources/Metrics/MetricsClientTest.php
+++ b/tests/Functional/Resources/Metrics/MetricsClientTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Functional\Resources\Metrics;
+
+use GuzzleHttp\Psr7\Response;
+use Http\Mock\Client as MockClient;
+use Paddle\SDK\Client;
+use Paddle\SDK\Entities\Metrics\MetricsActiveSubscribers;
+use Paddle\SDK\Entities\Metrics\MetricsChargebacks;
+use Paddle\SDK\Entities\Metrics\MetricsCheckoutConversion;
+use Paddle\SDK\Entities\Metrics\MetricsMonthlyRecurringRevenue;
+use Paddle\SDK\Entities\Metrics\MetricsMonthlyRecurringRevenueChange;
+use Paddle\SDK\Entities\Metrics\MetricsRefunds;
+use Paddle\SDK\Entities\Metrics\MetricsRevenue;
+use Paddle\SDK\Environment;
+use Paddle\SDK\Options;
+use Paddle\SDK\Resources\Metrics\Operations\GetMetrics;
+use Paddle\SDK\Tests\Utils\ReadsFixtures;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class MetricsClientTest extends TestCase
+{
+    use ReadsFixtures;
+
+    private MockClient $mockClient;
+    private Client $client;
+
+    public function setUp(): void
+    {
+        $this->mockClient = new MockClient();
+        $this->client = new Client(
+            apiKey: 'API_KEY_PLACEHOLDER',
+            options: new Options(Environment::SANDBOX),
+            httpClient: $this->mockClient,
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider metricsOperationsProvider
+     */
+    public function it_hits_expected_uri_for_metrics(
+        string $method,
+        string $fixture,
+        string $expectedPath,
+        string $expectedEntityClass,
+    ): void {
+        $expectedUri = sprintf(
+            '%s%s?from=2025-09-01&to=2025-09-05',
+            Environment::SANDBOX->baseUrl(),
+            $expectedPath,
+        );
+
+        $this->mockClient->addResponse(
+            new Response(200, body: self::readRawJsonFixture($fixture)),
+        );
+
+        $operation = new GetMetrics(from: '2025-09-01', to: '2025-09-05');
+        $result = $this->client->metrics->{$method}($operation);
+        $request = $this->mockClient->getLastRequest();
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($expectedUri, urldecode((string) $request->getUri()));
+        self::assertInstanceOf($expectedEntityClass, $result);
+    }
+
+    public static function metricsOperationsProvider(): \Generator
+    {
+        yield 'Get monthly recurring revenue' => [
+            'getMonthlyRecurringRevenue',
+            'response/monthly_recurring_revenue',
+            '/metrics/monthly-recurring-revenue',
+            MetricsMonthlyRecurringRevenue::class,
+        ];
+
+        yield 'Get monthly recurring revenue change' => [
+            'getMonthlyRecurringRevenueChange',
+            'response/monthly_recurring_revenue_change',
+            '/metrics/monthly-recurring-revenue-change',
+            MetricsMonthlyRecurringRevenueChange::class,
+        ];
+
+        yield 'Get active subscribers' => [
+            'getActiveSubscribers',
+            'response/active_subscribers',
+            '/metrics/active-subscribers',
+            MetricsActiveSubscribers::class,
+        ];
+
+        yield 'Get revenue' => [
+            'getRevenue',
+            'response/revenue',
+            '/metrics/revenue',
+            MetricsRevenue::class,
+        ];
+
+        yield 'Get refunds' => [
+            'getRefunds',
+            'response/refunds',
+            '/metrics/refunds',
+            MetricsRefunds::class,
+        ];
+
+        yield 'Get chargebacks' => [
+            'getChargebacks',
+            'response/chargebacks',
+            '/metrics/chargebacks',
+            MetricsChargebacks::class,
+        ];
+
+        yield 'Get checkout conversion' => [
+            'getCheckoutConversion',
+            'response/checkout_conversion',
+            '/metrics/checkout-conversion',
+            MetricsCheckoutConversion::class,
+        ];
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/active_subscribers.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/active_subscribers.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "count": 1250 },
+            { "timestamp": "2025-09-02T00:00:00Z", "count": 1267 },
+            { "timestamp": "2025-09-03T00:00:00Z", "count": 1284 },
+            { "timestamp": "2025-09-04T00:00:00Z", "count": 1291 }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/chargebacks.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/chargebacks.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "count": 1 },
+            { "timestamp": "2025-09-02T00:00:00Z", "count": 2 },
+            { "timestamp": "2025-09-03T00:00:00Z", "count": 0 },
+            { "timestamp": "2025-09-04T00:00:00Z", "count": 1 }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2026-03-03T06:30:32.811Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/checkout_conversion.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/checkout_conversion.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "count": 151, "completed_count": 5, "rate": "0.033113" },
+            { "timestamp": "2025-09-02T00:00:00Z", "count": 66, "completed_count": 11, "rate": "0.166667" },
+            { "timestamp": "2025-09-03T00:00:00Z", "count": 139, "completed_count": 12, "rate": "0.086331" },
+            { "timestamp": "2025-09-04T00:00:00Z", "count": 210, "completed_count": 28, "rate": "0.133333" }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/monthly_recurring_revenue.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/monthly_recurring_revenue.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "currency_code": "USD",
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "amount": "1286023068" },
+            { "timestamp": "2025-09-02T00:00:00Z", "amount": "1345678901" },
+            { "timestamp": "2025-09-03T00:00:00Z", "amount": "1398765432" },
+            { "timestamp": "2025-09-04T00:00:00Z", "amount": "1420987654" }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/monthly_recurring_revenue_change.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/monthly_recurring_revenue_change.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "currency_code": "USD",
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "amount": "125000" },
+            { "timestamp": "2025-09-02T00:00:00Z", "amount": "-75000" },
+            { "timestamp": "2025-09-03T00:00:00Z", "amount": "200000" },
+            { "timestamp": "2025-09-04T00:00:00Z", "amount": "50000" }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/refunds.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/refunds.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "currency_code": "USD",
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "amount": "10000" },
+            { "timestamp": "2025-09-02T00:00:00Z", "amount": "0" },
+            { "timestamp": "2025-09-03T00:00:00Z", "amount": "0" },
+            { "timestamp": "2025-09-04T00:00:00Z", "amount": "0" }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Functional/Resources/Metrics/_fixtures/response/revenue.json
+++ b/tests/Functional/Resources/Metrics/_fixtures/response/revenue.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "currency_code": "USD",
+        "timeseries": [
+            { "timestamp": "2025-09-01T00:00:00Z", "amount": "1286023068", "count": 100 },
+            { "timestamp": "2025-09-02T00:00:00Z", "amount": "1345678901", "count": 100 },
+            { "timestamp": "2025-09-03T00:00:00Z", "amount": "1398765432", "count": 100 },
+            { "timestamp": "2025-09-04T00:00:00Z", "amount": "1420987654", "count": 100 }
+        ],
+        "starts_at": "2025-09-01T00:00:00Z",
+        "ends_at": "2025-09-05T00:00:00Z",
+        "interval": "day",
+        "updated_at": "2025-09-04T20:30:00Z"
+    },
+    "meta": {
+        "request_id": "b93d9c94-c28f-4e5d-af2e-044854d7afe8"
+    }
+}

--- a/tests/Unit/Resources/Metrics/Operations/GetMetricsTest.php
+++ b/tests/Unit/Resources/Metrics/Operations/GetMetricsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Tests\Unit\Resources\Metrics\Operations;
+
+use Paddle\SDK\Resources\Metrics\Operations\GetMetrics;
+use PHPUnit\Framework\TestCase;
+
+class GetMetricsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_accepts_valid_date_strings(): void
+    {
+        $operation = new GetMetrics(from: '2025-09-01', to: '2025-09-05');
+
+        self::assertSame(['from' => '2025-09-01', 'to' => '2025-09-05'], $operation->getParameters());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidDatetimeProvider
+     */
+    public function it_rejects_datetime_strings(string $from, string $to): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('YYYY-MM-DD format');
+
+        new GetMetrics(from: $from, to: $to);
+    }
+
+    public static function invalidDatetimeProvider(): \Generator
+    {
+        yield 'from with datetime' => ['2025-09-01T00:00:00Z', '2025-09-05'];
+        yield 'to with datetime' => ['2025-09-01', '2025-09-05T23:59:59Z'];
+        yield 'from with microseconds' => ['2025-09-01T00:00:00.000000Z', '2025-09-05'];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider invalidDateStringProvider
+     */
+    public function it_rejects_invalid_date_strings(string $from, string $to): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('YYYY-MM-DD format');
+
+        new GetMetrics(from: $from, to: $to);
+    }
+
+    public static function invalidDateStringProvider(): \Generator
+    {
+        yield 'from not a date' => ['not-a-date', '2025-09-05'];
+        yield 'to not a date' => ['2025-09-01', 'invalid'];
+        yield 'from empty string' => ['', '2025-09-05'];
+        yield 'from wrong separator' => ['2025/09/01', '2025-09-05'];
+        yield 'from wrong order' => ['01-09-2025', '2025-09-05'];
+    }
+}


### PR DESCRIPTION
### Added

- Added support for metrics endpoints. See [related changelog](https://developer.paddle.com/changelog/2026/metrics-api?utm_source=dx&utm_medium=paddle-php-sdk)
  - `Client->metrics->getMonthlyRecurringRevenue()`
  - `Client->metrics->getMonthlyRecurringRevenueChange()`
  - `Client->metrics->getActiveSubscribers()`
  - `Client->metrics->getRevenue()`
  - `Client->metrics->getRefunds()`
  - `Client->metrics->getChargebacks()`
  - `Client->metrics->getCheckoutConversion()`