### PR TITLE
fix: Subscription one time charge for non-catalog products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
+## [1.17.1] - 2026-04-14
+
+### Added
+
+- Added dedicated one-time charge item types for subscriptions, resolving issues with non-catalog product serialization
+  - `SubscriptionChargeItem` — catalog item for one-time charges
+  - `SubscriptionChargeItemWithPrice` — non-catalog item for one-time charges
+  - `SubscriptionChargeNonCatalogPrice` — non-catalog price for existing products
+  - `SubscriptionChargeNonCatalogPriceWithProduct` — non-catalog price with inline product
+  - `SubscriptionChargeNonCatalogProduct` — non-catalog product for one-time charges
+
+### Fixed
+
+- Fixed one-time charge requests failing when using `SubscriptionItemsWithPrice` with `SubscriptionNonCatalogProduct` due to an extra `type` field being serialized
+
 ## [1.17.0] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [1.17.1] - 2026-04-28
+## [1.17.1] - 2026-04-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [1.17.1] - 2026-04-16
+## [1.17.1] - 2026-04-17
 
 ### Added
 
-- Added dedicated one-time charge item types for subscriptions, resolving issues with non-catalog product serialization
+- Added subscription operation models for update, preview update, and one-time charge requests
+  - `SubscriptionUpdateItem` — catalog item model for update and preview update operations
+  - `SubscriptionUpdateItemWithPrice` — non-catalog item model for update and preview update operations
+  - `SubscriptionNonCatalogPrice` — non-catalog price model for update and preview update operations
+  - `SubscriptionNonCatalogPriceWithProduct` — non-catalog price model with product for update and preview update operations
+  - `SubscriptionNonCatalogProduct` — non-catalog product model for subscription operations
   - `SubscriptionChargeItem` — catalog item for one-time charges
   - `SubscriptionChargeItemWithPrice` — non-catalog item for one-time charges
-  - `SubscriptionChargeNonCatalogPrice` — non-catalog price for existing products
-  - `SubscriptionChargeNonCatalogPriceWithProduct` — non-catalog price with inline product
-  - `SubscriptionChargeNonCatalogProduct` — non-catalog product for one-time charges
+  - `SubscriptionChargeNonCatalogPrice`— one-time charge non-catalog price model
+  - `SubscriptionChargeNonCatalogPriceWithProduct` — one-time charge non-catalog price model with product
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [1.17.1] - 2026-04-17
+## [1.17.1] - 2026-04-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Check our main [developer changelog](https://developer.paddle.com/?utm_source=dx&utm_medium=paddle-php-sdk) for information about changes to the Paddle Billing platform, the Paddle API, and other developer tools.
 
-## [1.17.1] - 2026-04-14
+## [1.17.1] - 2026-04-16
 
 ### Added
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,7 @@ use Symfony\Component\Uid\Ulid;
 
 class Client
 {
-    private const SDK_VERSION = '1.17.0';
+    private const SDK_VERSION = '1.17.1';
 
     public readonly LoggerInterface $logger;
     public readonly Options $options;

--- a/src/Entities/Subscription/SubscriptionItems.php
+++ b/src/Entities/Subscription/SubscriptionItems.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Subscription;
 
+/**
+ * @deprecated use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItem for update and preview update operations
+ */
 class SubscriptionItems
 {
     public function __construct(

--- a/src/Entities/Subscription/SubscriptionItemsWithPrice.php
+++ b/src/Entities/Subscription/SubscriptionItemsWithPrice.php
@@ -11,6 +11,9 @@ declare(strict_types=1);
 
 namespace Paddle\SDK\Entities\Subscription;
 
+/**
+ * @deprecated use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItemWithPrice for update and preview update operations
+ */
 class SubscriptionItemsWithPrice
 {
     public function __construct(

--- a/src/Entities/Subscription/SubscriptionNonCatalogPrice.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogPrice.php
@@ -18,6 +18,9 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
+/**
+ * @deprecated use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPrice instead
+ */
 class SubscriptionNonCatalogPrice
 {
     /**

--- a/src/Entities/Subscription/SubscriptionNonCatalogPriceWithProduct.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogPriceWithProduct.php
@@ -18,6 +18,9 @@ use Paddle\SDK\Entities\Shared\TaxMode;
 use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 
+/**
+ * @deprecated use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPriceWithProduct instead
+ */
 class SubscriptionNonCatalogPriceWithProduct
 {
     /**

--- a/src/Entities/Subscription/SubscriptionNonCatalogProduct.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogProduct.php
@@ -15,6 +15,9 @@ use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\TaxCategory;
 
+/**
+ * @deprecated use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogProduct instead
+ */
 class SubscriptionNonCatalogProduct implements \JsonSerializable
 {
     public function __construct(

--- a/src/Entities/Subscription/SubscriptionNonCatalogProduct.php
+++ b/src/Entities/Subscription/SubscriptionNonCatalogProduct.php
@@ -30,14 +30,12 @@ class SubscriptionNonCatalogProduct implements \JsonSerializable
 
     public function jsonSerialize(): array
     {
-        $data = [
+        return [
             'name' => $this->name,
             'description' => $this->description,
             'tax_category' => $this->taxCategory,
             'image_url' => $this->imageUrl,
             'custom_data' => $this->customData,
         ];
-
-        return array_filter($data, fn ($value) => $value !== null);
     }
 }

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItem.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItem.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * |------
- * | ! Generated code !
- * | Altering this code will result in changes being overwritten |
- * |-------------------------------------------------------------|.
- */
-
 namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
 
 class SubscriptionChargeItem

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItem.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItem.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+
+class SubscriptionChargeItem
+{
+    public function __construct(
+        public string $priceId,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItemWithPrice.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItemWithPrice.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * |------
- * | ! Generated code !
- * | Altering this code will result in changes being overwritten |
- * |-------------------------------------------------------------|.
- */
-
 namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
 
 class SubscriptionChargeItemWithPrice

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItemWithPrice.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeItemWithPrice.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+
+class SubscriptionChargeItemWithPrice
+{
+    public function __construct(
+        public SubscriptionChargeNonCatalogPrice|SubscriptionChargeNonCatalogPriceWithProduct $price,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPrice.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPrice.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Money;
+use Paddle\SDK\Entities\Shared\PriceQuantity;
+use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\UnitPriceOverride;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    /**
+     * @param array<UnitPriceOverride> $unitPriceOverrides
+     */
+    public function __construct(
+        public string $productId,
+        public string $description,
+        public Money $unitPrice,
+        public string|Undefined|null $name = new Undefined(),
+        public TaxMode|Undefined $taxMode = new Undefined(),
+        public array|Undefined $unitPriceOverrides = new Undefined(),
+        public PriceQuantity|Undefined $quantity = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'product_id' => $this->productId,
+            'description' => $this->description,
+            'unit_price' => $this->unitPrice,
+            'name' => $this->name,
+            'tax_mode' => $this->taxMode,
+            'unit_price_overrides' => $this->unitPriceOverrides,
+            'quantity' => $this->quantity,
+            'custom_data' => $this->customData,
+        ]);
+    }
+}

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPriceWithProduct.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPriceWithProduct.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * |------
+ * | ! Generated code !
+ * | Altering this code will result in changes being overwritten |
+ * |-------------------------------------------------------------|.
+ */
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+
+use Paddle\SDK\Entities\Shared\CustomData;
+use Paddle\SDK\Entities\Shared\Money;
+use Paddle\SDK\Entities\Shared\PriceQuantity;
+use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\UnitPriceOverride;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
+
+class SubscriptionChargeNonCatalogPriceWithProduct implements \JsonSerializable
+{
+    use FiltersUndefined;
+
+    /**
+     * @param array<UnitPriceOverride> $unitPriceOverrides
+     */
+    public function __construct(
+        public string $description,
+        public Money $unitPrice,
+        public SubscriptionChargeNonCatalogProduct $product,
+        public string|Undefined|null $name = new Undefined(),
+        public TaxMode|Undefined $taxMode = new Undefined(),
+        public array|Undefined $unitPriceOverrides = new Undefined(),
+        public PriceQuantity|Undefined $quantity = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->filterUndefined([
+            'description' => $this->description,
+            'unit_price' => $this->unitPrice,
+            'product' => $this->product,
+            'name' => $this->name,
+            'tax_mode' => $this->taxMode,
+            'unit_price_overrides' => $this->unitPriceOverrides,
+            'quantity' => $this->quantity,
+            'custom_data' => $this->customData,
+        ]);
+    }
+}

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPriceWithProduct.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogPriceWithProduct.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * |------
- * | ! Generated code !
- * | Altering this code will result in changes being overwritten |
- * |-------------------------------------------------------------|.
- */
-
 namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
 
 use Paddle\SDK\Entities\Shared\CustomData;

--- a/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogProduct.php
+++ b/src/Resources/Subscriptions/Operations/Charge/SubscriptionChargeNonCatalogProduct.php
@@ -9,35 +9,34 @@ declare(strict_types=1);
  * |-------------------------------------------------------------|.
  */
 
-namespace Paddle\SDK\Entities\Subscription;
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
 
-use Paddle\SDK\Entities\Shared\CatalogType;
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\TaxCategory;
+use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Undefined;
 
-class SubscriptionNonCatalogProduct implements \JsonSerializable
+class SubscriptionChargeNonCatalogProduct implements \JsonSerializable
 {
+    use FiltersUndefined;
+
     public function __construct(
         public string $name,
-        public string|null $description,
-        /** @deprecated Not accepted by the API. Ignored during serialization. Will be removed in a future version. */
-        public CatalogType|null $type,
         public TaxCategory $taxCategory,
-        public string|null $imageUrl,
-        public CustomData|null $customData,
+        public string|Undefined|null $description = new Undefined(),
+        public string|Undefined|null $imageUrl = new Undefined(),
+        public CustomData|Undefined|null $customData = new Undefined(),
     ) {
     }
 
     public function jsonSerialize(): array
     {
-        $data = [
+        return $this->filterUndefined([
             'name' => $this->name,
             'description' => $this->description,
             'tax_category' => $this->taxCategory,
             'image_url' => $this->imageUrl,
             'custom_data' => $this->customData,
-        ];
-
-        return array_filter($data, fn ($value) => $value !== null);
+        ]);
     }
 }

--- a/src/Resources/Subscriptions/Operations/CreateOneTimeCharge.php
+++ b/src/Resources/Subscriptions/Operations/CreateOneTimeCharge.php
@@ -9,6 +9,8 @@ use Paddle\SDK\Entities\Subscription\SubscriptionItems;
 use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class CreateOneTimeCharge implements \JsonSerializable
@@ -16,7 +18,7 @@ class CreateOneTimeCharge implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
+     * @param array<SubscriptionChargeItem|SubscriptionChargeItemWithPrice|SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly SubscriptionEffectiveFrom $effectiveFrom,

--- a/src/Resources/Subscriptions/Operations/PreviewOneTimeCharge.php
+++ b/src/Resources/Subscriptions/Operations/PreviewOneTimeCharge.php
@@ -9,6 +9,8 @@ use Paddle\SDK\Entities\Subscription\SubscriptionItems;
 use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\FiltersUndefined;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class PreviewOneTimeCharge implements \JsonSerializable
@@ -16,7 +18,7 @@ class PreviewOneTimeCharge implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
+     * @param array<SubscriptionChargeItem|SubscriptionChargeItemWithPrice|SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly SubscriptionEffectiveFrom $effectiveFrom,

--- a/src/Resources/Subscriptions/Operations/PreviewUpdateSubscription.php
+++ b/src/Resources/Subscriptions/Operations/PreviewUpdateSubscription.php
@@ -15,6 +15,8 @@ use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionDiscount;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class PreviewUpdateSubscription implements \JsonSerializable
@@ -22,7 +24,7 @@ class PreviewUpdateSubscription implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
+     * @param array<SubscriptionUpdateItem|SubscriptionUpdateItemWithPrice|SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly string|Undefined $customerId = new Undefined(),

--- a/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogPrice.php
+++ b/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogPrice.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Price;
 
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Undefined;
 
-class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
+class SubscriptionNonCatalogPrice implements \JsonSerializable
 {
     use FiltersUndefined;
 
@@ -20,10 +21,12 @@ class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
      * @param array<UnitPriceOverride> $unitPriceOverrides
      */
     public function __construct(
-        public string $productId,
         public string $description,
         public Money $unitPrice,
+        public string $productId,
         public string|Undefined|null $name = new Undefined(),
+        public TimePeriod|Undefined|null $billingCycle = new Undefined(),
+        public TimePeriod|Undefined|null $trialPeriod = new Undefined(),
         public TaxMode|Undefined $taxMode = new Undefined(),
         public array|Undefined $unitPriceOverrides = new Undefined(),
         public PriceQuantity|Undefined $quantity = new Undefined(),
@@ -34,10 +37,12 @@ class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return $this->filterUndefined([
-            'product_id' => $this->productId,
             'description' => $this->description,
             'unit_price' => $this->unitPrice,
+            'product_id' => $this->productId,
             'name' => $this->name,
+            'billing_cycle' => $this->billingCycle,
+            'trial_period' => $this->trialPeriod,
             'tax_mode' => $this->taxMode,
             'unit_price_overrides' => $this->unitPriceOverrides,
             'quantity' => $this->quantity,

--- a/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogPriceWithProduct.php
+++ b/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogPriceWithProduct.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Price;
 
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\Money;
 use Paddle\SDK\Entities\Shared\PriceQuantity;
 use Paddle\SDK\Entities\Shared\TaxMode;
+use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Shared\UnitPriceOverride;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Undefined;
 
-class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
+class SubscriptionNonCatalogPriceWithProduct implements \JsonSerializable
 {
     use FiltersUndefined;
 
@@ -20,10 +21,12 @@ class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
      * @param array<UnitPriceOverride> $unitPriceOverrides
      */
     public function __construct(
-        public string $productId,
         public string $description,
         public Money $unitPrice,
+        public SubscriptionNonCatalogProduct $product,
         public string|Undefined|null $name = new Undefined(),
+        public TimePeriod|Undefined|null $billingCycle = new Undefined(),
+        public TimePeriod|Undefined|null $trialPeriod = new Undefined(),
         public TaxMode|Undefined $taxMode = new Undefined(),
         public array|Undefined $unitPriceOverrides = new Undefined(),
         public PriceQuantity|Undefined $quantity = new Undefined(),
@@ -34,10 +37,12 @@ class SubscriptionChargeNonCatalogPrice implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return $this->filterUndefined([
-            'product_id' => $this->productId,
             'description' => $this->description,
             'unit_price' => $this->unitPrice,
+            'product' => $this->product,
             'name' => $this->name,
+            'billing_cycle' => $this->billingCycle,
+            'trial_period' => $this->trialPeriod,
             'tax_mode' => $this->taxMode,
             'unit_price_overrides' => $this->unitPriceOverrides,
             'quantity' => $this->quantity,

--- a/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogProduct.php
+++ b/src/Resources/Subscriptions/Operations/Price/SubscriptionNonCatalogProduct.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Paddle\SDK\Resources\Subscriptions\Operations\Charge;
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Price;
 
 use Paddle\SDK\Entities\Shared\CustomData;
 use Paddle\SDK\Entities\Shared\TaxCategory;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Undefined;
 
-class SubscriptionChargeNonCatalogProduct implements \JsonSerializable
+class SubscriptionNonCatalogProduct implements \JsonSerializable
 {
     use FiltersUndefined;
 

--- a/src/Resources/Subscriptions/Operations/Update/SubscriptionUpdateItem.php
+++ b/src/Resources/Subscriptions/Operations/Update/SubscriptionUpdateItem.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Update;
+
+use Paddle\SDK\Undefined;
+
+class SubscriptionUpdateItem
+{
+    public function __construct(
+        public string $priceId,
+        public int|Undefined $quantity = new Undefined(),
+    ) {
+    }
+}

--- a/src/Resources/Subscriptions/Operations/Update/SubscriptionUpdateItemWithPrice.php
+++ b/src/Resources/Subscriptions/Operations/Update/SubscriptionUpdateItemWithPrice.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paddle\SDK\Resources\Subscriptions\Operations\Update;
+
+use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPrice;
+use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPriceWithProduct;
+
+class SubscriptionUpdateItemWithPrice
+{
+    public function __construct(
+        public SubscriptionNonCatalogPrice|SubscriptionNonCatalogPriceWithProduct $price,
+        public int $quantity,
+    ) {
+    }
+}

--- a/src/Resources/Subscriptions/Operations/UpdateSubscription.php
+++ b/src/Resources/Subscriptions/Operations/UpdateSubscription.php
@@ -15,6 +15,8 @@ use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
 use Paddle\SDK\FiltersUndefined;
 use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionDiscount;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItemWithPrice;
 use Paddle\SDK\Undefined;
 
 class UpdateSubscription implements \JsonSerializable
@@ -22,7 +24,7 @@ class UpdateSubscription implements \JsonSerializable
     use FiltersUndefined;
 
     /**
-     * @param array<SubscriptionItems|SubscriptionItemsWithPrice> $items
+     * @param array<SubscriptionUpdateItem|SubscriptionUpdateItemWithPrice|SubscriptionItems|SubscriptionItemsWithPrice> $items
      */
     public function __construct(
         public readonly string|Undefined $customerId = new Undefined(),

--- a/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
+++ b/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
@@ -33,6 +33,11 @@ use Paddle\SDK\Environment;
 use Paddle\SDK\Options;
 use Paddle\SDK\Resources\Shared\Operations\List\Pager;
 use Paddle\SDK\Resources\Subscriptions\Operations\CancelSubscription;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeItemWithPrice;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeNonCatalogPrice;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeNonCatalogPriceWithProduct;
+use Paddle\SDK\Resources\Subscriptions\Operations\Charge\SubscriptionChargeNonCatalogProduct;
 use Paddle\SDK\Resources\Subscriptions\Operations\CreateOneTimeCharge;
 use Paddle\SDK\Resources\Subscriptions\Operations\Get\Includes;
 use Paddle\SDK\Resources\Subscriptions\Operations\ListSubscriptions;
@@ -569,6 +574,69 @@ class SubscriptionsClientTest extends TestCase
             new Response(200, body: self::readRawJsonFixture('response/full_entity')),
             self::readRawJsonFixture('request/create_one_time_charge_full'),
         ];
+
+        yield 'Charge Catalog Item' => [
+            new CreateOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItem('pri_01gsz98e27ak2tyhexptwc58yk', 1),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/create_one_time_charge_minimal'),
+        ];
+
+        yield 'Charge Non-Catalog Price' => [
+            new CreateOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPrice(
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            'One-time setup fee',
+                            new Money('1000', CurrencyCode::USD()),
+                            'Setup Fee',
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(1, 1),
+                            new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/create_one_time_charge_non_catalog_price'),
+        ];
+
+        yield 'Charge Non-Catalog Price and Product' => [
+            new CreateOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPriceWithProduct(
+                            'One-time setup fee',
+                            new Money('1000', CurrencyCode::USD()),
+                            new SubscriptionChargeNonCatalogProduct(
+                                'Custom Setup',
+                                TaxCategory::DigitalGoods(),
+                                'One-time custom setup service',
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            'Setup Fee',
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(1, 1),
+                            new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/create_one_time_charge_non_catalog_price_and_product'),
+        ];
     }
 
     /**
@@ -723,6 +791,69 @@ class SubscriptionsClientTest extends TestCase
             ),
             new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
             self::readRawJsonFixture('request/preview_one_time_charge_full'),
+        ];
+
+        yield 'Preview Charge Catalog Item' => [
+            new PreviewOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItem('pri_01gsz98e27ak2tyhexptwc58yk', 1),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
+            self::readRawJsonFixture('request/preview_one_time_charge_minimal'),
+        ];
+
+        yield 'Preview Charge Non-Catalog Price' => [
+            new PreviewOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPrice(
+                            'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            'One-time setup fee',
+                            new Money('1000', CurrencyCode::USD()),
+                            'Setup Fee',
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(1, 1),
+                            new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
+            self::readRawJsonFixture('request/preview_one_time_charge_non_catalog_price'),
+        ];
+
+        yield 'Preview Charge Non-Catalog Price and Product' => [
+            new PreviewOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPriceWithProduct(
+                            'One-time setup fee',
+                            new Money('1000', CurrencyCode::USD()),
+                            new SubscriptionChargeNonCatalogProduct(
+                                'Custom Setup',
+                                TaxCategory::DigitalGoods(),
+                                'One-time custom setup service',
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            'Setup Fee',
+                            TaxMode::AccountSetting(),
+                            [],
+                            new PriceQuantity(1, 1),
+                            new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
+            self::readRawJsonFixture('request/preview_one_time_charge_non_catalog_price_and_product'),
         ];
     }
 

--- a/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
+++ b/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
@@ -20,9 +20,9 @@ use Paddle\SDK\Entities\Shared\TimePeriod;
 use Paddle\SDK\Entities\Subscription\SubscriptionEffectiveFrom;
 use Paddle\SDK\Entities\Subscription\SubscriptionItems;
 use Paddle\SDK\Entities\Subscription\SubscriptionItemsWithPrice;
-use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPrice;
-use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPriceWithProduct;
-use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogProduct;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPrice as EntitySubscriptionNonCatalogPrice;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogPriceWithProduct as EntitySubscriptionNonCatalogPriceWithProduct;
+use Paddle\SDK\Entities\Subscription\SubscriptionNonCatalogProduct as EntitySubscriptionNonCatalogProduct;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnPaymentFailure;
 use Paddle\SDK\Entities\Subscription\SubscriptionOnResume;
 use Paddle\SDK\Entities\Subscription\SubscriptionProrationBillingMode;
@@ -44,8 +44,13 @@ use Paddle\SDK\Resources\Subscriptions\Operations\ListSubscriptions;
 use Paddle\SDK\Resources\Subscriptions\Operations\PauseSubscription;
 use Paddle\SDK\Resources\Subscriptions\Operations\PreviewOneTimeCharge;
 use Paddle\SDK\Resources\Subscriptions\Operations\PreviewUpdateSubscription;
+use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPrice;
+use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogPriceWithProduct;
+use Paddle\SDK\Resources\Subscriptions\Operations\Price\SubscriptionNonCatalogProduct;
 use Paddle\SDK\Resources\Subscriptions\Operations\ResumeSubscription;
 use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionDiscount;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItem;
+use Paddle\SDK\Resources\Subscriptions\Operations\Update\SubscriptionUpdateItemWithPrice;
 use Paddle\SDK\Resources\Subscriptions\Operations\UpdateSubscription;
 use Paddle\SDK\Tests\Utils\ReadsFixtures;
 use PHPUnit\Framework\TestCase;
@@ -108,25 +113,22 @@ class SubscriptionsClientTest extends TestCase
         yield 'Update Non-Catalog Product With Null Values' => [
             new UpdateSubscription(
                 items: [
-                    new SubscriptionItemsWithPrice(
+                    new SubscriptionUpdateItemWithPrice(
                         new SubscriptionNonCatalogPriceWithProduct(
-                            'some description',
-                            'some name',
-                            new SubscriptionNonCatalogProduct(
-                                'some name',
-                                null,
-                                null,
-                                TaxCategory::DigitalGoods(),
-                                null,
-                                null,
+                            description: 'some description',
+                            unitPrice: new Money('1', CurrencyCode::GBP()),
+                            product: new SubscriptionNonCatalogProduct(
+                                name: 'some name',
+                                taxCategory: TaxCategory::DigitalGoods(),
+                                description: null,
+                                imageUrl: null,
+                                customData: null,
                             ),
-                            TaxMode::AccountSetting(),
-                            new Money('1', CurrencyCode::GBP()),
-                            [],
-                            new PriceQuantity(1, 3),
-                            null,
-                            new TimePeriod(Interval::Day(), 1),
-                            new TimePeriod(Interval::Day(), 2),
+                            name: 'some name',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 3),
+                            customData: null,
                         ),
                         2,
                     ),
@@ -155,7 +157,7 @@ class SubscriptionsClientTest extends TestCase
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
                     new SubscriptionItemsWithPrice(
-                        new SubscriptionNonCatalogPrice(
+                        new EntitySubscriptionNonCatalogPrice(
                             'some description',
                             'some name',
                             'pro_01gsz4t5hdjse780zja8vvr7jg',
@@ -170,10 +172,10 @@ class SubscriptionsClientTest extends TestCase
                         2,
                     ),
                     new SubscriptionItemsWithPrice(
-                        new SubscriptionNonCatalogPriceWithProduct(
+                        new EntitySubscriptionNonCatalogPriceWithProduct(
                             'some description',
                             'some name',
-                            new SubscriptionNonCatalogProduct(
+                            new EntitySubscriptionNonCatalogProduct(
                                 'some name',
                                 'some description',
                                 CatalogType::Custom(),
@@ -197,6 +199,67 @@ class SubscriptionsClientTest extends TestCase
             ),
             new Response(200, body: self::readRawJsonFixture('response/full_entity')),
             self::readRawJsonFixture('request/update_full'),
+        ];
+
+        yield 'Update All (Operation Models)' => [
+            new UpdateSubscription(
+                customerId: 'ctm_01h8441jn5pcwrfhwh78jqt8hk',
+                addressId: 'add_01h848pep46enq8y372x7maj0p',
+                businessId: null,
+                currencyCode: CurrencyCode::GBP(),
+                nextBilledAt: new \DateTimeImmutable('2023-11-06 14:00:00'),
+                discount: new SubscriptionDiscount(
+                    'dsc_01h848pep46enq8y372x7maj0p',
+                    SubscriptionEffectiveFrom::NextBillingPeriod(),
+                ),
+                collectionMode: CollectionMode::Automatic(),
+                billingDetails: null,
+                scheduledChange: null,
+                items: [
+                    new SubscriptionUpdateItem('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
+                    new SubscriptionUpdateItem('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
+                    new SubscriptionUpdateItemWithPrice(
+                        new SubscriptionNonCatalogPrice(
+                            description: 'some description',
+                            unitPrice: new Money('1', CurrencyCode::GBP()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'some name',
+                            billingCycle: new TimePeriod(Interval::Day(), 1),
+                            trialPeriod: new TimePeriod(Interval::Day(), 2),
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 3),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        2,
+                    ),
+                    new SubscriptionUpdateItemWithPrice(
+                        new SubscriptionNonCatalogPriceWithProduct(
+                            description: 'some description',
+                            unitPrice: new Money('1', CurrencyCode::GBP()),
+                            product: new SubscriptionNonCatalogProduct(
+                                'some name',
+                                TaxCategory::DigitalGoods(),
+                                'some description',
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            name: 'some name',
+                            billingCycle: new TimePeriod(Interval::Day(), 1),
+                            trialPeriod: new TimePeriod(Interval::Day(), 2),
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 3),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        2,
+                    ),
+                ],
+                customData: new CustomData(['early_access' => true]),
+                prorationBillingMode: SubscriptionProrationBillingMode::FullImmediately(),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/update_full_operation_models'),
         ];
     }
 
@@ -618,20 +681,72 @@ class SubscriptionsClientTest extends TestCase
             self::readRawJsonFixture('request/create_one_time_charge_minimal'),
         ];
 
+        yield 'Charge Non-Catalog Price (Operation Models)' => [
+            new CreateOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPrice(
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/create_one_time_charge_non_catalog_price'),
+        ];
+
+        yield 'Charge Non-Catalog Price and Product (Operation Models)' => [
+            new CreateOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPriceWithProduct(
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            product: new SubscriptionChargeNonCatalogProduct(
+                                name: 'Custom Setup',
+                                taxCategory: TaxCategory::DigitalGoods(),
+                                description: 'One-time custom setup service',
+                                imageUrl: 'https://www.example.com/image.jpg',
+                                customData: new CustomData(['key' => 'value']),
+                            ),
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/create_one_time_charge_non_catalog_price_and_product'),
+        ];
+
         yield 'Charge Non-Catalog Price' => [
             new CreateOneTimeCharge(
                 SubscriptionEffectiveFrom::NextBillingPeriod(),
                 [
                     new SubscriptionChargeItemWithPrice(
                         new SubscriptionChargeNonCatalogPrice(
-                            'pro_01gsz4t5hdjse780zja8vvr7jg',
-                            'One-time setup fee',
-                            new Money('1000', CurrencyCode::USD()),
-                            'Setup Fee',
-                            TaxMode::AccountSetting(),
-                            [],
-                            new PriceQuantity(1, 1),
-                            new CustomData(['key' => 'value']),
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
                         ),
                         1,
                     ),
@@ -647,20 +762,20 @@ class SubscriptionsClientTest extends TestCase
                 [
                     new SubscriptionChargeItemWithPrice(
                         new SubscriptionChargeNonCatalogPriceWithProduct(
-                            'One-time setup fee',
-                            new Money('1000', CurrencyCode::USD()),
-                            new SubscriptionChargeNonCatalogProduct(
-                                'Custom Setup',
-                                TaxCategory::DigitalGoods(),
-                                'One-time custom setup service',
-                                'https://www.example.com/image.jpg',
-                                new CustomData(['key' => 'value']),
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            product: new SubscriptionChargeNonCatalogProduct(
+                                name: 'Custom Setup',
+                                taxCategory: TaxCategory::DigitalGoods(),
+                                description: 'One-time custom setup service',
+                                imageUrl: 'https://www.example.com/image.jpg',
+                                customData: new CustomData(['key' => 'value']),
                             ),
-                            'Setup Fee',
-                            TaxMode::AccountSetting(),
-                            [],
-                            new PriceQuantity(1, 1),
-                            new CustomData(['key' => 'value']),
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
                         ),
                         1,
                     ),
@@ -731,7 +846,7 @@ class SubscriptionsClientTest extends TestCase
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
                     new SubscriptionItems('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
                     new SubscriptionItemsWithPrice(
-                        new SubscriptionNonCatalogPrice(
+                        new EntitySubscriptionNonCatalogPrice(
                             'some description',
                             'some name',
                             'pro_01gsz4t5hdjse780zja8vvr7jg',
@@ -746,10 +861,10 @@ class SubscriptionsClientTest extends TestCase
                         2,
                     ),
                     new SubscriptionItemsWithPrice(
-                        new SubscriptionNonCatalogPriceWithProduct(
+                        new EntitySubscriptionNonCatalogPriceWithProduct(
                             'some description',
                             'some name',
-                            new SubscriptionNonCatalogProduct(
+                            new EntitySubscriptionNonCatalogProduct(
                                 'some name',
                                 'some description',
                                 CatalogType::Custom(),
@@ -773,6 +888,67 @@ class SubscriptionsClientTest extends TestCase
             ),
             new Response(200, body: self::readRawJsonFixture('response/preview_update_full_entity')),
             self::readRawJsonFixture('request/preview_update_full'),
+        ];
+
+        yield 'Preview Update All (Operation Models)' => [
+            new PreviewUpdateSubscription(
+                customerId: 'ctm_01h8441jn5pcwrfhwh78jqt8hk',
+                addressId: 'add_01h848pep46enq8y372x7maj0p',
+                businessId: null,
+                currencyCode: CurrencyCode::GBP(),
+                nextBilledAt: new \DateTimeImmutable('2023-11-06 14:00:00'),
+                discount: new SubscriptionDiscount(
+                    'dsc_01h848pep46enq8y372x7maj0p',
+                    SubscriptionEffectiveFrom::NextBillingPeriod(),
+                ),
+                collectionMode: CollectionMode::Automatic(),
+                billingDetails: null,
+                scheduledChange: null,
+                items: [
+                    new SubscriptionUpdateItem('pri_01gsz91wy9k1yn7kx82aafwvea', 1),
+                    new SubscriptionUpdateItem('pri_01gsz91wy9k1yn7kx82bafwvea', 5),
+                    new SubscriptionUpdateItemWithPrice(
+                        new SubscriptionNonCatalogPrice(
+                            description: 'some description',
+                            unitPrice: new Money('1', CurrencyCode::GBP()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'some name',
+                            billingCycle: new TimePeriod(Interval::Day(), 1),
+                            trialPeriod: new TimePeriod(Interval::Day(), 2),
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 3),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        2,
+                    ),
+                    new SubscriptionUpdateItemWithPrice(
+                        new SubscriptionNonCatalogPriceWithProduct(
+                            description: 'some description',
+                            unitPrice: new Money('1', CurrencyCode::GBP()),
+                            product: new SubscriptionNonCatalogProduct(
+                                'some name',
+                                TaxCategory::DigitalGoods(),
+                                'some description',
+                                'https://www.example.com/image.jpg',
+                                new CustomData(['key' => 'value']),
+                            ),
+                            name: 'some name',
+                            billingCycle: new TimePeriod(Interval::Day(), 1),
+                            trialPeriod: new TimePeriod(Interval::Day(), 2),
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 3),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        2,
+                    ),
+                ],
+                customData: new CustomData(['early_access' => true]),
+                prorationBillingMode: SubscriptionProrationBillingMode::FullImmediately(),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_update_full_entity')),
+            self::readRawJsonFixture('request/preview_update_full_operation_models'),
         ];
     }
 
@@ -836,20 +1012,72 @@ class SubscriptionsClientTest extends TestCase
             self::readRawJsonFixture('request/preview_one_time_charge_minimal'),
         ];
 
+        yield 'Preview Charge Non-Catalog Price (Operation Models)' => [
+            new PreviewOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPrice(
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
+            self::readRawJsonFixture('request/preview_one_time_charge_non_catalog_price'),
+        ];
+
+        yield 'Preview Charge Non-Catalog Price and Product (Operation Models)' => [
+            new PreviewOneTimeCharge(
+                SubscriptionEffectiveFrom::NextBillingPeriod(),
+                [
+                    new SubscriptionChargeItemWithPrice(
+                        new SubscriptionChargeNonCatalogPriceWithProduct(
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            product: new SubscriptionChargeNonCatalogProduct(
+                                name: 'Custom Setup',
+                                taxCategory: TaxCategory::DigitalGoods(),
+                                description: 'One-time custom setup service',
+                                imageUrl: 'https://www.example.com/image.jpg',
+                                customData: new CustomData(['key' => 'value']),
+                            ),
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
+                        ),
+                        1,
+                    ),
+                ],
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/preview_charge_full_entity')),
+            self::readRawJsonFixture('request/preview_one_time_charge_non_catalog_price_and_product'),
+        ];
+
         yield 'Preview Charge Non-Catalog Price' => [
             new PreviewOneTimeCharge(
                 SubscriptionEffectiveFrom::NextBillingPeriod(),
                 [
                     new SubscriptionChargeItemWithPrice(
                         new SubscriptionChargeNonCatalogPrice(
-                            'pro_01gsz4t5hdjse780zja8vvr7jg',
-                            'One-time setup fee',
-                            new Money('1000', CurrencyCode::USD()),
-                            'Setup Fee',
-                            TaxMode::AccountSetting(),
-                            [],
-                            new PriceQuantity(1, 1),
-                            new CustomData(['key' => 'value']),
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            productId: 'pro_01gsz4t5hdjse780zja8vvr7jg',
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
                         ),
                         1,
                     ),
@@ -865,20 +1093,20 @@ class SubscriptionsClientTest extends TestCase
                 [
                     new SubscriptionChargeItemWithPrice(
                         new SubscriptionChargeNonCatalogPriceWithProduct(
-                            'One-time setup fee',
-                            new Money('1000', CurrencyCode::USD()),
-                            new SubscriptionChargeNonCatalogProduct(
-                                'Custom Setup',
-                                TaxCategory::DigitalGoods(),
-                                'One-time custom setup service',
-                                'https://www.example.com/image.jpg',
-                                new CustomData(['key' => 'value']),
+                            description: 'One-time setup fee',
+                            unitPrice: new Money('1000', CurrencyCode::USD()),
+                            product: new SubscriptionChargeNonCatalogProduct(
+                                name: 'Custom Setup',
+                                taxCategory: TaxCategory::DigitalGoods(),
+                                description: 'One-time custom setup service',
+                                imageUrl: 'https://www.example.com/image.jpg',
+                                customData: new CustomData(['key' => 'value']),
                             ),
-                            'Setup Fee',
-                            TaxMode::AccountSetting(),
-                            [],
-                            new PriceQuantity(1, 1),
-                            new CustomData(['key' => 'value']),
+                            name: 'Setup Fee',
+                            taxMode: TaxMode::AccountSetting(),
+                            unitPriceOverrides: [],
+                            quantity: new PriceQuantity(1, 1),
+                            customData: new CustomData(['key' => 'value']),
                         ),
                         1,
                     ),

--- a/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
+++ b/tests/Functional/Resources/Subscriptions/SubscriptionsClientTest.php
@@ -105,6 +105,38 @@ class SubscriptionsClientTest extends TestCase
             self::readRawJsonFixture('request/update_partial'),
         ];
 
+        yield 'Update Non-Catalog Product With Null Values' => [
+            new UpdateSubscription(
+                items: [
+                    new SubscriptionItemsWithPrice(
+                        new SubscriptionNonCatalogPriceWithProduct(
+                            'some description',
+                            'some name',
+                            new SubscriptionNonCatalogProduct(
+                                'some name',
+                                null,
+                                null,
+                                TaxCategory::DigitalGoods(),
+                                null,
+                                null,
+                            ),
+                            TaxMode::AccountSetting(),
+                            new Money('1', CurrencyCode::GBP()),
+                            [],
+                            new PriceQuantity(1, 3),
+                            null,
+                            new TimePeriod(Interval::Day(), 1),
+                            new TimePeriod(Interval::Day(), 2),
+                        ),
+                        2,
+                    ),
+                ],
+                prorationBillingMode: SubscriptionProrationBillingMode::FullImmediately(),
+            ),
+            new Response(200, body: self::readRawJsonFixture('response/full_entity')),
+            self::readRawJsonFixture('request/update_non_catalog_product_with_nulls'),
+        ];
+
         yield 'Update All' => [
             new UpdateSubscription(
                 customerId: 'ctm_01h8441jn5pcwrfhwh78jqt8hk',

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/create_one_time_charge_non_catalog_price.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/create_one_time_charge_non_catalog_price.json
@@ -1,0 +1,26 @@
+{
+    "effective_from": "next_billing_period",
+    "items": [
+        {
+            "quantity": 1,
+            "price": {
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "description": "One-time setup fee",
+                "name": "Setup Fee",
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 1,
+                    "maximum": 1
+                },
+                "custom_data": {
+                    "key": "value"
+                }
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/create_one_time_charge_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/create_one_time_charge_non_catalog_price_and_product.json
@@ -1,0 +1,34 @@
+{
+    "effective_from": "next_billing_period",
+    "items": [
+        {
+            "quantity": 1,
+            "price": {
+                "description": "One-time setup fee",
+                "name": "Setup Fee",
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 1,
+                    "maximum": 1
+                },
+                "custom_data": {
+                    "key": "value"
+                },
+                "product": {
+                    "name": "Custom Setup",
+                    "description": "One-time custom setup service",
+                    "tax_category": "digital-goods",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "custom_data": {
+                        "key": "value"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_one_time_charge_non_catalog_price.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_one_time_charge_non_catalog_price.json
@@ -1,0 +1,26 @@
+{
+    "effective_from": "next_billing_period",
+    "items": [
+        {
+            "quantity": 1,
+            "price": {
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "description": "One-time setup fee",
+                "name": "Setup Fee",
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 1,
+                    "maximum": 1
+                },
+                "custom_data": {
+                    "key": "value"
+                }
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_one_time_charge_non_catalog_price_and_product.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_one_time_charge_non_catalog_price_and_product.json
@@ -1,0 +1,34 @@
+{
+    "effective_from": "next_billing_period",
+    "items": [
+        {
+            "quantity": 1,
+            "price": {
+                "description": "One-time setup fee",
+                "name": "Setup Fee",
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1000",
+                    "currency_code": "USD"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "minimum": 1,
+                    "maximum": 1
+                },
+                "custom_data": {
+                    "key": "value"
+                },
+                "product": {
+                    "name": "Custom Setup",
+                    "description": "One-time custom setup service",
+                    "tax_category": "digital-goods",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "custom_data": {
+                        "key": "value"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full.json
@@ -57,8 +57,7 @@
                     "description": "some description",
                     "image_url": "https://www.example.com/image.jpg",
                     "name": "some name",
-                    "tax_category": "digital-goods",
-                    "type": "custom"
+                    "tax_category": "digital-goods"
                 },
                 "quantity": {
                     "maximum": 3,

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full_operation_models.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_full_operation_models.json
@@ -1,0 +1,88 @@
+{
+    "customer_id": "ctm_01h8441jn5pcwrfhwh78jqt8hk",
+    "address_id": "add_01h848pep46enq8y372x7maj0p",
+    "business_id": null,
+    "currency_code": "GBP",
+    "next_billed_at": "2023-11-06T14:00:00.000000Z",
+    "discount": {
+        "id": "dsc_01h848pep46enq8y372x7maj0p",
+        "effective_from": "next_billing_period"
+    },
+    "collection_mode": "automatic",
+    "billing_details": null,
+    "scheduled_change": null,
+    "items": [
+        { "price_id": "pri_01gsz91wy9k1yn7kx82aafwvea", "quantity": 1 },
+        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product": {
+                    "custom_data": {
+                        "key": "value"
+                    },
+                    "description": "some description",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "name": "some name",
+                    "tax_category": "digital-goods"
+                },
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        }
+    ],
+    "proration_billing_mode": "full_immediately",
+    "custom_data": {
+        "early_access": true
+    }
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_non_catalog_product_with_nulls.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/preview_update_non_catalog_product_with_nulls.json
@@ -21,6 +21,14 @@
                 "quantity": {
                     "maximum": 3,
                     "minimum": 1
+                },
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
                 }
             },
             "quantity": 2

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full.json
@@ -57,8 +57,7 @@
                     "description": "some description",
                     "image_url": "https://www.example.com/image.jpg",
                     "name": "some name",
-                    "tax_category": "digital-goods",
-                    "type": "custom"
+                    "tax_category": "digital-goods"
                 },
                 "quantity": {
                     "maximum": 3,

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full_operation_models.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/update_full_operation_models.json
@@ -1,0 +1,88 @@
+{
+    "customer_id": "ctm_01h8441jn5pcwrfhwh78jqt8hk",
+    "address_id": "add_01h848pep46enq8y372x7maj0p",
+    "business_id": null,
+    "currency_code": "GBP",
+    "next_billed_at": "2023-11-06T14:00:00.000000Z",
+    "discount": {
+        "id": "dsc_01h848pep46enq8y372x7maj0p",
+        "effective_from": "next_billing_period"
+    },
+    "collection_mode": "automatic",
+    "billing_details": null,
+    "scheduled_change": null,
+    "items": [
+        { "price_id": "pri_01gsz91wy9k1yn7kx82aafwvea", "quantity": 1 },
+        { "price_id": "pri_01gsz91wy9k1yn7kx82bafwvea", "quantity": 5 },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product_id": "pro_01gsz4t5hdjse780zja8vvr7jg",
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        },
+        {
+            "price": {
+                "custom_data": {
+                    "key": "value"
+                },
+                "description": "some description",
+                "name": "some name",
+                "product": {
+                    "custom_data": {
+                        "key": "value"
+                    },
+                    "description": "some description",
+                    "image_url": "https://www.example.com/image.jpg",
+                    "name": "some name",
+                    "tax_category": "digital-goods"
+                },
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        }
+    ],
+    "proration_billing_mode": "full_immediately",
+    "custom_data": {
+        "early_access": true
+    }
+}

--- a/tests/Functional/Resources/Subscriptions/_fixtures/request/update_non_catalog_product_with_nulls.json
+++ b/tests/Functional/Resources/Subscriptions/_fixtures/request/update_non_catalog_product_with_nulls.json
@@ -1,0 +1,38 @@
+{
+    "items": [
+        {
+            "price": {
+                "description": "some description",
+                "name": "some name",
+                "product": {
+                    "name": "some name",
+                    "description": null,
+                    "tax_category": "digital-goods",
+                    "image_url": null,
+                    "custom_data": null
+                },
+                "custom_data": null,
+                "tax_mode": "account_setting",
+                "unit_price": {
+                    "amount": "1",
+                    "currency_code": "GBP"
+                },
+                "unit_price_overrides": [],
+                "quantity": {
+                    "maximum": 3,
+                    "minimum": 1
+                },
+                "billing_cycle": {
+                    "frequency": 1,
+                    "interval": "day"
+                },
+                "trial_period": {
+                    "frequency": 2,
+                    "interval": "day"
+                }
+            },
+            "quantity": 2
+        }
+    ],
+    "proration_billing_mode": "full_immediately"
+}


### PR DESCRIPTION
### Added

- Added subscription operation models for update, preview update, and one-time charge requests
  - `SubscriptionUpdateItem` — catalog item model for update and preview update operations
  - `SubscriptionUpdateItemWithPrice` — non-catalog item model for update and preview update operations
  - `SubscriptionNonCatalogPrice` — non-catalog price model for update and preview update operations
  - `SubscriptionNonCatalogPriceWithProduct` — non-catalog price model with product for update and preview update operations
  - `SubscriptionNonCatalogProduct` — non-catalog product model for subscription operations
  - `SubscriptionChargeItem` — catalog item for one-time charges
  - `SubscriptionChargeItemWithPrice` — non-catalog item for one-time charges
  - `SubscriptionChargeNonCatalogPrice`— one-time charge non-catalog price model
  - `SubscriptionChargeNonCatalogPriceWithProduct` — one-time charge non-catalog price model with product

### Fixed

- Fixed one-time charge requests failing when using `SubscriptionItemsWithPrice` with `SubscriptionNonCatalogProduct` due to an extra `type` field being serialized